### PR TITLE
modification for faster sramvaluerequest

### DIFF
--- a/SetupCANFlash/SetupCANFlash.vdproj
+++ b/SetupCANFlash/SetupCANFlash.vdproj
@@ -15,26 +15,38 @@
     {
         "Entry"
         {
-        "MsmKey" = "8:_1CD663634790325E7A026BEAFF7B9EB4"
+        "MsmKey" = "8:_2527A57EE00F0382E049C8C3BC571E31"
         "OwnerKey" = "8:_3C87B40D8D4F4B188624286CF0A35439"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
         {
-        "MsmKey" = "8:_1CD663634790325E7A026BEAFF7B9EB4"
-        "OwnerKey" = "8:_BAFCC793B41C6A448DEA42B07F4E19EE"
+        "MsmKey" = "8:_2527A57EE00F0382E049C8C3BC571E31"
+        "OwnerKey" = "8:_A6F3939FE93BC722A7B6897E9B3021D3"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
         {
-        "MsmKey" = "8:_23B5D70299C2332EB74C0DD6053D7BDB"
+        "MsmKey" = "8:_350D920C519A45F015F527CBC414E73E"
         "OwnerKey" = "8:_3C87B40D8D4F4B188624286CF0A35439"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
         {
-        "MsmKey" = "8:_23B5D70299C2332EB74C0DD6053D7BDB"
-        "OwnerKey" = "8:_BAFCC793B41C6A448DEA42B07F4E19EE"
+        "MsmKey" = "8:_350D920C519A45F015F527CBC414E73E"
+        "OwnerKey" = "8:_A6F3939FE93BC722A7B6897E9B3021D3"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
+        "MsmKey" = "8:_3B13366349764C6034443358DBAE7C5C"
+        "OwnerKey" = "8:_2527A57EE00F0382E049C8C3BC571E31"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
+        "MsmKey" = "8:_3B13366349764C6034443358DBAE7C5C"
+        "OwnerKey" = "8:_3C87B40D8D4F4B188624286CF0A35439"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
@@ -45,49 +57,31 @@
         }
         "Entry"
         {
-        "MsmKey" = "8:_67C8A3B4B33DC993F775EB8B685F49F7"
+        "MsmKey" = "8:_4912DDA357EABCDF18E6969DE4DB8DB2"
+        "OwnerKey" = "8:_2527A57EE00F0382E049C8C3BC571E31"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
+        "MsmKey" = "8:_4912DDA357EABCDF18E6969DE4DB8DB2"
         "OwnerKey" = "8:_3C87B40D8D4F4B188624286CF0A35439"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
         {
-        "MsmKey" = "8:_67C8A3B4B33DC993F775EB8B685F49F7"
-        "OwnerKey" = "8:_BAFCC793B41C6A448DEA42B07F4E19EE"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_7B58566DB4AE4974A67199ACD5BC18ED"
+        "MsmKey" = "8:_9AC05F8E407ECB28F3A28D033FD4B652"
         "OwnerKey" = "8:_3C87B40D8D4F4B188624286CF0A35439"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
         {
-        "MsmKey" = "8:_7B58566DB4AE4974A67199ACD5BC18ED"
-        "OwnerKey" = "8:_BAFCC793B41C6A448DEA42B07F4E19EE"
+        "MsmKey" = "8:_9AC05F8E407ECB28F3A28D033FD4B652"
+        "OwnerKey" = "8:_A6F3939FE93BC722A7B6897E9B3021D3"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
         {
-        "MsmKey" = "8:_A437E1A2EF91AB37C80E69415C904FF6"
-        "OwnerKey" = "8:_23B5D70299C2332EB74C0DD6053D7BDB"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_A437E1A2EF91AB37C80E69415C904FF6"
-        "OwnerKey" = "8:_3C87B40D8D4F4B188624286CF0A35439"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_A783ECB6E78272932FA103FA11F74616"
-        "OwnerKey" = "8:_23B5D70299C2332EB74C0DD6053D7BDB"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_A783ECB6E78272932FA103FA11F74616"
+        "MsmKey" = "8:_A6F3939FE93BC722A7B6897E9B3021D3"
         "OwnerKey" = "8:_3C87B40D8D4F4B188624286CF0A35439"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -99,56 +93,62 @@
         }
         "Entry"
         {
-        "MsmKey" = "8:_BAFCC793B41C6A448DEA42B07F4E19EE"
+        "MsmKey" = "8:_CA4B748E75E2B8DA464F92CE8DD510F6"
+        "OwnerKey" = "8:_3C87B40D8D4F4B188624286CF0A35439"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
+        "MsmKey" = "8:_CA4B748E75E2B8DA464F92CE8DD510F6"
+        "OwnerKey" = "8:_A6F3939FE93BC722A7B6897E9B3021D3"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
+        "MsmKey" = "8:_UNDEFINED"
         "OwnerKey" = "8:_3C87B40D8D4F4B188624286CF0A35439"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
         {
         "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_3C87B40D8D4F4B188624286CF0A35439"
+        "OwnerKey" = "8:_A6F3939FE93BC722A7B6897E9B3021D3"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
         {
         "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_BAFCC793B41C6A448DEA42B07F4E19EE"
+        "OwnerKey" = "8:_2527A57EE00F0382E049C8C3BC571E31"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
         {
         "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_23B5D70299C2332EB74C0DD6053D7BDB"
+        "OwnerKey" = "8:_3B13366349764C6034443358DBAE7C5C"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
         {
         "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_A783ECB6E78272932FA103FA11F74616"
+        "OwnerKey" = "8:_4912DDA357EABCDF18E6969DE4DB8DB2"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
         {
         "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_A437E1A2EF91AB37C80E69415C904FF6"
+        "OwnerKey" = "8:_CA4B748E75E2B8DA464F92CE8DD510F6"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
         {
         "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_67C8A3B4B33DC993F775EB8B685F49F7"
+        "OwnerKey" = "8:_350D920C519A45F015F527CBC414E73E"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
         {
         "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_1CD663634790325E7A026BEAFF7B9EB4"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_7B58566DB4AE4974A67199ACD5BC18ED"
+        "OwnerKey" = "8:_9AC05F8E407ECB28F3A28D033FD4B652"
         "MsmSig" = "8:_UNDEFINED"
         }
     }
@@ -261,45 +261,14 @@
         }
         "File"
         {
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_1CD663634790325E7A026BEAFF7B9EB4"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:canlibCLSNET, Version=8.8.823.1, Culture=neutral, PublicKeyToken=bb7f2cd46200de24, processorArchitecture=x86"
-                "ScatterAssemblies"
-                {
-                    "_1CD663634790325E7A026BEAFF7B9EB4"
-                    {
-                    "Name" = "8:canlibCLSNET.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:canlibCLSNET.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_8A7D23B3CF51495AA0821C00BEC94ACD"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:TRUE"
-            "IsolateTo" = "8:"
-            }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_23B5D70299C2332EB74C0DD6053D7BDB"
+            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_2527A57EE00F0382E049C8C3BC571E31"
             {
             "AssemblyRegister" = "3:1"
             "AssemblyIsInGAC" = "11:FALSE"
             "AssemblyAsmDisplayName" = "8:combilib-net, Version=1.0.5571.38176, Culture=neutral, processorArchitecture=x86"
                 "ScatterAssemblies"
                 {
-                    "_23B5D70299C2332EB74C0DD6053D7BDB"
+                    "_2527A57EE00F0382E049C8C3BC571E31"
                     {
                     "Name" = "8:combilib-net.dll"
                     "Attributes" = "3:512"
@@ -323,20 +292,20 @@
             "IsDependency" = "11:TRUE"
             "IsolateTo" = "8:"
             }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_67C8A3B4B33DC993F775EB8B685F49F7"
+            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_350D920C519A45F015F527CBC414E73E"
             {
             "AssemblyRegister" = "3:1"
             "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:canusbdrv_net, Version=2.0.0.1, Culture=neutral, processorArchitecture=x86"
+            "AssemblyAsmDisplayName" = "8:canlibCLSNET, Version=8.8.823.1, Culture=neutral, PublicKeyToken=bb7f2cd46200de24, processorArchitecture=x86"
                 "ScatterAssemblies"
                 {
-                    "_67C8A3B4B33DC993F775EB8B685F49F7"
+                    "_350D920C519A45F015F527CBC414E73E"
                     {
-                    "Name" = "8:canusbdrv_net.dll"
+                    "Name" = "8:canlibCLSNET.dll"
                     "Attributes" = "3:512"
                     }
                 }
-            "SourcePath" = "8:canusbdrv_net.dll"
+            "SourcePath" = "8:canlibCLSNET.dll"
             "TargetName" = "8:"
             "Tag" = "8:"
             "Folder" = "8:_8A7D23B3CF51495AA0821C00BEC94ACD"
@@ -354,20 +323,20 @@
             "IsDependency" = "11:TRUE"
             "IsolateTo" = "8:"
             }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_7B58566DB4AE4974A67199ACD5BC18ED"
+            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_3B13366349764C6034443358DBAE7C5C"
             {
             "AssemblyRegister" = "3:1"
             "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:NLog, Version=3.2.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL"
+            "AssemblyAsmDisplayName" = "8:LibUsbDotNet, Version=2.2.8.104, Culture=neutral, processorArchitecture=MSIL"
                 "ScatterAssemblies"
                 {
-                    "_7B58566DB4AE4974A67199ACD5BC18ED"
+                    "_3B13366349764C6034443358DBAE7C5C"
                     {
-                    "Name" = "8:NLog.dll"
+                    "Name" = "8:LibUsbDotNet.dll"
                     "Attributes" = "3:512"
                     }
                 }
-            "SourcePath" = "8:NLog.dll"
+            "SourcePath" = "8:LibUsbDotNet.dll"
             "TargetName" = "8:"
             "Tag" = "8:"
             "Folder" = "8:_8A7D23B3CF51495AA0821C00BEC94ACD"
@@ -385,14 +354,14 @@
             "IsDependency" = "11:TRUE"
             "IsolateTo" = "8:"
             }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_A437E1A2EF91AB37C80E69415C904FF6"
+            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_4912DDA357EABCDF18E6969DE4DB8DB2"
             {
             "AssemblyRegister" = "3:1"
             "AssemblyIsInGAC" = "11:FALSE"
             "AssemblyAsmDisplayName" = "8:FTD2XX_NET, Version=1.0.10.0, Culture=neutral, PublicKeyToken=61a8105588f51b1f, processorArchitecture=MSIL"
                 "ScatterAssemblies"
                 {
-                    "_A437E1A2EF91AB37C80E69415C904FF6"
+                    "_4912DDA357EABCDF18E6969DE4DB8DB2"
                     {
                     "Name" = "8:FTD2XX_NET.dll"
                     "Attributes" = "3:512"
@@ -416,20 +385,51 @@
             "IsDependency" = "11:TRUE"
             "IsolateTo" = "8:"
             }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_A783ECB6E78272932FA103FA11F74616"
+            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_9AC05F8E407ECB28F3A28D033FD4B652"
             {
             "AssemblyRegister" = "3:1"
             "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:LibUsbDotNet, Version=2.2.8.104, Culture=neutral, processorArchitecture=MSIL"
+            "AssemblyAsmDisplayName" = "8:NLog, Version=3.2.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL"
                 "ScatterAssemblies"
                 {
-                    "_A783ECB6E78272932FA103FA11F74616"
+                    "_9AC05F8E407ECB28F3A28D033FD4B652"
                     {
-                    "Name" = "8:LibUsbDotNet.dll"
+                    "Name" = "8:NLog.dll"
                     "Attributes" = "3:512"
                     }
                 }
-            "SourcePath" = "8:LibUsbDotNet.dll"
+            "SourcePath" = "8:NLog.dll"
+            "TargetName" = "8:"
+            "Tag" = "8:"
+            "Folder" = "8:_8A7D23B3CF51495AA0821C00BEC94ACD"
+            "Condition" = "8:"
+            "Transitive" = "11:FALSE"
+            "Vital" = "11:TRUE"
+            "ReadOnly" = "11:FALSE"
+            "Hidden" = "11:FALSE"
+            "System" = "11:FALSE"
+            "Permanent" = "11:FALSE"
+            "SharedLegacy" = "11:FALSE"
+            "PackageAs" = "3:1"
+            "Register" = "3:1"
+            "Exclude" = "11:FALSE"
+            "IsDependency" = "11:TRUE"
+            "IsolateTo" = "8:"
+            }
+            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_A6F3939FE93BC722A7B6897E9B3021D3"
+            {
+            "AssemblyRegister" = "3:1"
+            "AssemblyIsInGAC" = "11:FALSE"
+            "AssemblyAsmDisplayName" = "8:TrionicCANLib, Version=0.1.16.0, Culture=neutral, processorArchitecture=MSIL"
+                "ScatterAssemblies"
+                {
+                    "_A6F3939FE93BC722A7B6897E9B3021D3"
+                    {
+                    "Name" = "8:TrionicCANLib.dll"
+                    "Attributes" = "3:512"
+                    }
+                }
+            "SourcePath" = "8:TrionicCANLib.dll"
             "TargetName" = "8:"
             "Tag" = "8:"
             "Folder" = "8:_8A7D23B3CF51495AA0821C00BEC94ACD"
@@ -467,20 +467,20 @@
             "IsDependency" = "11:FALSE"
             "IsolateTo" = "8:"
             }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_BAFCC793B41C6A448DEA42B07F4E19EE"
+            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_CA4B748E75E2B8DA464F92CE8DD510F6"
             {
             "AssemblyRegister" = "3:1"
             "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:TrionicCANLib, Version=0.1.16.0, Culture=neutral, processorArchitecture=x86"
+            "AssemblyAsmDisplayName" = "8:canusbdrv_net, Version=2.0.0.1, Culture=neutral, processorArchitecture=x86"
                 "ScatterAssemblies"
                 {
-                    "_BAFCC793B41C6A448DEA42B07F4E19EE"
+                    "_CA4B748E75E2B8DA464F92CE8DD510F6"
                     {
-                    "Name" = "8:TrionicCANLib.dll"
+                    "Name" = "8:canusbdrv_net.dll"
                     "Attributes" = "3:512"
                     }
                 }
-            "SourcePath" = "8:TrionicCANLib.dll"
+            "SourcePath" = "8:canusbdrv_net.dll"
             "TargetName" = "8:"
             "Tag" = "8:"
             "Folder" = "8:_8A7D23B3CF51495AA0821C00BEC94ACD"
@@ -555,7 +555,7 @@
         "Name" = "8:Microsoft Visual Studio"
         "ProductName" = "8:TrionicCANFlash"
         "ProductCode" = "8:{FCCEE342-1E3B-4120-ACDE-F31FA9283667}"
-        "PackageCode" = "8:{7DCA1A71-D219-4C34-AA78-2F4A9D6794D0}"
+        "PackageCode" = "8:{9F065842-84B0-4055-8724-9B1371071546}"
         "UpgradeCode" = "8:{9B523E43-7324-4DF0-A1DE-8493B57D1915}"
         "AspNetVersion" = "8:4.0.30319.0"
         "RestartWWWService" = "11:FALSE"
@@ -1104,7 +1104,7 @@
         {
             "{5259A561-127C-4D43-A0A1-72F10C7B3BF8}:_3C87B40D8D4F4B188624286CF0A35439"
             {
-            "SourcePath" = "8:..\\TrionicCANFlasher\\obj\\x86\\Debug\\TrionicCANFlasher.exe"
+            "SourcePath" = "8:..\\TrionicCANFlasher\\obj\\Release\\TrionicCANFlasher.exe"
             "TargetName" = "8:"
             "Tag" = "8:"
             "Folder" = "8:_8A7D23B3CF51495AA0821C00BEC94ACD"

--- a/TrionicCANLib/CAN/CANELM327Device.cs
+++ b/TrionicCANLib/CAN/CANELM327Device.cs
@@ -97,7 +97,7 @@ namespace TrionicCANLib.CAN
             CANMessage canMessage = new CANMessage();
             StringBuilder receiveText = new StringBuilder();
 
-            logger.Trace("readMessages started");
+            logger.Debug("readMessages started");
             while (true)
             {
                 receiveDataSemaphore.WaitOne();
@@ -106,7 +106,7 @@ namespace TrionicCANLib.CAN
                 {
                     if (m_endThread)
                     {
-                        logger.Trace("readMessages ended");
+                        logger.Debug("readMessages ended");
                         return;
                     }
                 }
@@ -148,7 +148,7 @@ namespace TrionicCANLib.CAN
                                 else if (rxMessage.StartsWith("NO DATA"))
                                 {
                                     logger.Debug("NO DATA");
-                                    logger.Trace("NO DATA");
+                                    logger.Debug("NO DATA");
                                 }
                                 else if (rxMessage.Length == 19) // is it a valid line
                                 {
@@ -165,7 +165,7 @@ namespace TrionicCANLib.CAN
 
                                             lock (m_listeners)
                                             {
-                                                logger.Trace(string.Format("rx: {0} {1}", canMessage.getID().ToString("X3"), canMessage.getData().ToString("X16")));
+                                                logger.Debug(string.Format("rx: {0} {1}", canMessage.getID().ToString("X3"), canMessage.getData().ToString("X16")));
                                                 foreach (ICANListener listener in m_listeners)
                                                 {
                                                     listener.handleMessage(canMessage);
@@ -175,7 +175,7 @@ namespace TrionicCANLib.CAN
                                     }
                                     catch (Exception)
                                     {
-                                        //logger.Trace("MSG: " + rxMessage);
+                                        //logger.Debug("MSG: " + rxMessage);
                                     }
                                 }
                                  //disable whitespace logging
@@ -257,7 +257,7 @@ namespace TrionicCANLib.CAN
                 {
                     lastSentTimestamp = Environment.TickCount;
                     WriteToSerialWithTrace(sendString);
-                    logger.Trace(string.Format("TX: {0} {1}", a_message.getID().ToString("X3"), sendString));
+                    logger.Debug(string.Format("TX: {0} {1}", a_message.getID().ToString("X3"), sendString));
                 }
                 return true; // remove after implementation
             }
@@ -664,11 +664,11 @@ namespace TrionicCANLib.CAN
             while (tries-- > 0)
             {
                 WriteToSerialAndWait("ATI\r");
-                Console.Write(".");
+                logger.Debug(".");
             }
             start = Environment.TickCount - start;
             logger.Debug(string.Format("Got {0} responses in {1} ms", 1000, start));
-            logger.Trace(string.Format("Got {0} responses in {1} ms", 1000, start));
+            logger.Debug(string.Format("Got {0} responses in {1} ms", 1000, start));
         }
 
         private void RunLoggingBenchmark()

--- a/TrionicCANLib/CAN/CANELM327Device.cs
+++ b/TrionicCANLib/CAN/CANELM327Device.cs
@@ -32,7 +32,7 @@ namespace TrionicCANLib.CAN
         private Semaphore sendDataSempahore = new Semaphore(1, 1);
         private bool request0Responses = false;
         private long lastSentTimestamp = 0;
-        private Logger logger = LogManager.GetCurrentClassLogger();
+        private static Logger logger = LogManager.GetCurrentClassLogger();
 
         object lockObj = new object();
 
@@ -97,7 +97,7 @@ namespace TrionicCANLib.CAN
             CANMessage canMessage = new CANMessage();
             StringBuilder receiveText = new StringBuilder();
 
-            Console.WriteLine("readMessages started");
+            logger.Trace("readMessages started");
             while (true)
             {
                 receiveDataSemaphore.WaitOne();
@@ -106,7 +106,7 @@ namespace TrionicCANLib.CAN
                 {
                     if (m_endThread)
                     {
-                        Console.WriteLine("readMessages ended");
+                        logger.Trace("readMessages ended");
                         return;
                     }
                 }
@@ -148,7 +148,7 @@ namespace TrionicCANLib.CAN
                                 else if (rxMessage.StartsWith("NO DATA"))
                                 {
                                     logger.Debug("NO DATA");
-                                    Console.WriteLine("NO DATA");
+                                    logger.Trace("NO DATA");
                                 }
                                 else if (rxMessage.Length == 19) // is it a valid line
                                 {
@@ -175,7 +175,7 @@ namespace TrionicCANLib.CAN
                                     }
                                     catch (Exception)
                                     {
-                                        //Console.WriteLine("MSG: " + rxMessage);
+                                        //logger.Trace("MSG: " + rxMessage);
                                     }
                                 }
                                  //disable whitespace logging
@@ -668,7 +668,7 @@ namespace TrionicCANLib.CAN
             }
             start = Environment.TickCount - start;
             logger.Debug(string.Format("Got {0} responses in {1} ms", 1000, start));
-            Console.WriteLine(string.Format("Got {0} responses in {1} ms", 1000, start));
+            logger.Trace(string.Format("Got {0} responses in {1} ms", 1000, start));
         }
 
         private void RunLoggingBenchmark()

--- a/TrionicCANLib/CAN/CANListener.cs
+++ b/TrionicCANLib/CAN/CANListener.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Threading;
 using System.IO;
 using System.Diagnostics;
+using NLog;
 
 namespace TrionicCANLib.CAN
 {
@@ -12,6 +13,7 @@ namespace TrionicCANLib.CAN
     /// </summary>
     class CANListener : ICANListener
     {
+        private static Logger logger = LogManager.GetCurrentClassLogger();
         private uint m_waitMsgID = 0;
         private uint m_additionalWaitMsgID = 0;
 
@@ -114,19 +116,19 @@ namespace TrionicCANLib.CAN
             {
                 if (_receiveMessageIndex == idx && _readMessageIndex == idx)
                 {
-                    Console.WriteLine(_queue[idx].getID().ToString("X3") + " " + _queue[idx].getData().ToString("X16") + " RX RD");
+                    logger.Trace(_queue[idx].getID().ToString("X3") + " " + _queue[idx].getData().ToString("X16") + " RX RD");
                 }
                 else if (_receiveMessageIndex == idx)
                 {
-                    Console.WriteLine(_queue[idx].getID().ToString("X3") + " " + _queue[idx].getData().ToString("X16") + " RX");
+                    logger.Trace(_queue[idx].getID().ToString("X3") + " " + _queue[idx].getData().ToString("X16") + " RX");
                 }
                 else if (_readMessageIndex == idx)
                 {
-                    Console.WriteLine(_queue[idx].getID().ToString("X3") + " " + _queue[idx].getData().ToString("X16") + "    RD");
+                    logger.Trace(_queue[idx].getID().ToString("X3") + " " + _queue[idx].getData().ToString("X16") + "    RD");
                 }
                 else
                 {
-                    Console.WriteLine(_queue[idx].getID().ToString("X3") + " " + _queue[idx].getData().ToString("X16"));
+                    logger.Trace(_queue[idx].getID().ToString("X3") + " " + _queue[idx].getData().ToString("X16"));
 
                 }
             }
@@ -179,7 +181,7 @@ namespace TrionicCANLib.CAN
             }
             if (size > 1)
             {
-                Console.WriteLine("Buffering: " + size.ToString() + " messages");
+                logger.Trace("Buffering: " + size.ToString() + " messages");
                 //dumpQueue();
             }
         }

--- a/TrionicCANLib/CAN/CANListener.cs
+++ b/TrionicCANLib/CAN/CANListener.cs
@@ -116,19 +116,19 @@ namespace TrionicCANLib.CAN
             {
                 if (_receiveMessageIndex == idx && _readMessageIndex == idx)
                 {
-                    logger.Trace(_queue[idx].getID().ToString("X3") + " " + _queue[idx].getData().ToString("X16") + " RX RD");
+                    logger.Debug(_queue[idx].getID().ToString("X3") + " " + _queue[idx].getData().ToString("X16") + " RX RD");
                 }
                 else if (_receiveMessageIndex == idx)
                 {
-                    logger.Trace(_queue[idx].getID().ToString("X3") + " " + _queue[idx].getData().ToString("X16") + " RX");
+                    logger.Debug(_queue[idx].getID().ToString("X3") + " " + _queue[idx].getData().ToString("X16") + " RX");
                 }
                 else if (_readMessageIndex == idx)
                 {
-                    logger.Trace(_queue[idx].getID().ToString("X3") + " " + _queue[idx].getData().ToString("X16") + "    RD");
+                    logger.Debug(_queue[idx].getID().ToString("X3") + " " + _queue[idx].getData().ToString("X16") + "    RD");
                 }
                 else
                 {
-                    logger.Trace(_queue[idx].getID().ToString("X3") + " " + _queue[idx].getData().ToString("X16"));
+                    logger.Debug(_queue[idx].getID().ToString("X3") + " " + _queue[idx].getData().ToString("X16"));
 
                 }
             }
@@ -181,7 +181,7 @@ namespace TrionicCANLib.CAN
             }
             if (size > 1)
             {
-                logger.Trace("Buffering: " + size.ToString() + " messages");
+                logger.Debug("Buffering: " + size.ToString() + " messages");
                 //dumpQueue();
             }
         }

--- a/TrionicCANLib/CAN/CANMXWiFiDevice.cs
+++ b/TrionicCANLib/CAN/CANMXWiFiDevice.cs
@@ -90,8 +90,8 @@ namespace TrionicCANLib.CAN
             foreach (NetworkInterface Interface in Interfaces)
             {
                 if (Interface.NetworkInterfaceType == NetworkInterfaceType.Loopback) continue;
-                logger.Trace(Interface.Description);
-                logger.Trace(Interface.Name);
+                logger.Debug(Interface.Description);
+                logger.Debug(Interface.Name);
                 UnicastIPAddressInformationCollection addresses = Interface.GetIPProperties().UnicastAddresses;
                 foreach (UnicastIPAddressInformation address in addresses)
                 {
@@ -154,20 +154,20 @@ namespace TrionicCANLib.CAN
         {
             CANMessage canMessage = new CANMessage();
 
-            logger.Trace("readMessages started");
+            logger.Debug("readMessages started");
             while (true)
             {
                 lock (m_synchObject)
                 {
                     if (m_endThread)
                     {
-                        logger.Trace("readMessages ended");
+                        logger.Debug("readMessages ended");
                         return;
                     }
                 }
                 if (rawString != null)
                 {
-                    logger.Trace(String.Format("Raw Data: {0}", rawString));
+                    logger.Debug(String.Format("Raw Data: {0}", rawString));
                     //AddToSerialTrace("RAW RX: " + rawString.Replace("\r",m_cr_sequence));
                     string rxString = rawString.Replace("\r", m_cr_sequence); //replace , because stringbuilder cannot handle \r
                     bool isStopped = false;
@@ -199,7 +199,7 @@ namespace TrionicCANLib.CAN
 
                                         lock (m_listeners)
                                         {
-                                            logger.Trace(string.Format("rx: {0} {1}", canMessage.getID().ToString("X3"), canMessage.getData().ToString("X16")));
+                                            logger.Debug(string.Format("rx: {0} {1}", canMessage.getID().ToString("X3"), canMessage.getData().ToString("X16")));
                                             foreach (ICANListener listener in m_listeners)
                                             {
                                                 listener.handleMessage(canMessage);
@@ -209,7 +209,7 @@ namespace TrionicCANLib.CAN
                                 }
                                 catch (Exception)
                                 {
-                                    //logger.Trace("MSG: " + rxMessage);
+                                    //logger.Debug("MSG: " + rxMessage);
                                 }
                             }
                             //disable whitespace logging
@@ -259,7 +259,7 @@ namespace TrionicCANLib.CAN
 
                 lastSentTimestamp = Environment.TickCount;
                 rawString = WriteToTelnetAndWait(sendString);
-                logger.Trace(string.Format("tx: {0} {1}", a_message.getID().ToString("X3"), sendString));
+                logger.Debug(string.Format("tx: {0} {1}", a_message.getID().ToString("X3"), sendString));
 
                 return true; // remove after implementation
             }

--- a/TrionicCANLib/CAN/CANMXWiFiDevice.cs
+++ b/TrionicCANLib/CAN/CANMXWiFiDevice.cs
@@ -27,7 +27,7 @@ namespace TrionicCANLib.CAN
         private bool interfaceBusy;
 
         private long lastSentTimestamp = 0;
-        private readonly Logger logger = LogManager.GetCurrentClassLogger();
+        private static Logger logger = LogManager.GetCurrentClassLogger();
 
         readonly object lockObj = new object();
 
@@ -90,8 +90,8 @@ namespace TrionicCANLib.CAN
             foreach (NetworkInterface Interface in Interfaces)
             {
                 if (Interface.NetworkInterfaceType == NetworkInterfaceType.Loopback) continue;
-                Console.WriteLine(Interface.Description);
-                Console.WriteLine(Interface.Name);
+                logger.Trace(Interface.Description);
+                logger.Trace(Interface.Name);
                 UnicastIPAddressInformationCollection addresses = Interface.GetIPProperties().UnicastAddresses;
                 foreach (UnicastIPAddressInformation address in addresses)
                 {
@@ -154,14 +154,14 @@ namespace TrionicCANLib.CAN
         {
             CANMessage canMessage = new CANMessage();
 
-            Console.WriteLine("readMessages started");
+            logger.Trace("readMessages started");
             while (true)
             {
                 lock (m_synchObject)
                 {
                     if (m_endThread)
                     {
-                        Console.WriteLine("readMessages ended");
+                        logger.Trace("readMessages ended");
                         return;
                     }
                 }
@@ -209,7 +209,7 @@ namespace TrionicCANLib.CAN
                                 }
                                 catch (Exception)
                                 {
-                                    //Console.WriteLine("MSG: " + rxMessage);
+                                    //logger.Trace("MSG: " + rxMessage);
                                 }
                             }
                             //disable whitespace logging

--- a/TrionicCANLib/CAN/CANMessage.cs
+++ b/TrionicCANLib/CAN/CANMessage.cs
@@ -15,23 +15,27 @@ namespace TrionicCANLib.CAN
         /// m_id is the CAN id
         /// </summary>
         private uint m_id;			// 11/29 bit Identifier
+        
         /// <summary>
         /// m_timestamp is the time stamp for the message set by the CAN device
         /// </summary>
         private uint m_timestamp;   // Hardware Timestamp (0-9999mS)
+        
         /// <summary>
         /// m_flags is flags set by the CAN device (vendor dependent)
         /// </summary>
         private byte m_flags;		// Message Flags
+        
         /// <summary>
         /// m_length is the number of bytes in the message
         /// </summary>
         private byte m_length;		// Number of data bytes 0-8.
+        
         /// <summary>
         /// m_data is the data contained in the CAN message.
         /// Data is ordered in reverse orded compared to the CAN message. If the message should
         /// contain [0x11,0x22,0x33,0x44,0x55,0x66,0x77,0x88] m_data should have the 
-        /// value 0x887766554432211.
+        /// value 0x8877665544332211.
         /// </summary>
         private ulong m_data;		// Data Bytes 0..7
 

--- a/TrionicCANLib/CAN/CANUSBDevice.cs
+++ b/TrionicCANLib/CAN/CANUSBDevice.cs
@@ -138,7 +138,7 @@ namespace TrionicCANLib.CAN
                         canMessage.setData(r_canMsg.data);
                         lock (m_listeners)
                         {
-                            logger.Trace(string.Format("rx: {0} {1}", canMessage.getID().ToString("X3"), canMessage.getData().ToString("X16")));
+                            logger.Debug(string.Format("rx: {0} {1}", canMessage.getID().ToString("X3"), canMessage.getData().ToString("X16")));
                             foreach (ICANListener listener in m_listeners)
                             {
                                 listener.handleMessage(canMessage);
@@ -294,12 +294,12 @@ namespace TrionicCANLib.CAN
             writeResult = Lawicel.CANUSB.canusb_Write(m_deviceHandle, ref msg);
             if (writeResult == Lawicel.CANUSB.ERROR_CANUSB_OK)
             {
-                logger.Trace("tx: " + msg.id.ToString("X3") + " " + msg.data.ToString("X16"));
+                logger.Debug("tx: " + msg.id.ToString("X3") + " " + msg.data.ToString("X16"));
                 return true;
             }
             else
             {
-                logger.Trace("tx: " + msg.id.ToString("X3") + " " + msg.data.ToString("X16") + " failed" + writeResult);
+                logger.Debug("tx: " + msg.id.ToString("X3") + " " + msg.data.ToString("X16") + " failed" + writeResult);
                 return false;
             }
         }
@@ -324,7 +324,7 @@ namespace TrionicCANLib.CAN
                 if (readResult == Lawicel.CANUSB.ERROR_CANUSB_OK)
                 {
                     Thread.Sleep(1);
-                    logger.Trace("rx: 0x" + r_canMsg.id.ToString("X3") + r_canMsg.data.ToString("X16"));
+                    logger.Debug("rx: 0x" + r_canMsg.id.ToString("X3") + r_canMsg.data.ToString("X16"));
                     if (r_canMsg.id == 0x00)
                     {
                         nrOfWait++;

--- a/TrionicCANLib/CAN/Just4TrionicDevice.cs
+++ b/TrionicCANLib/CAN/Just4TrionicDevice.cs
@@ -15,7 +15,7 @@ namespace TrionicCANLib.CAN
         Thread m_readThread;
         Object m_synchObject = new Object();
         bool m_endThread = false;
-        private Logger logger = LogManager.GetCurrentClassLogger();
+        private static Logger logger = LogManager.GetCurrentClassLogger();
 
         private int m_forcedBaudrate = 115200;
 
@@ -62,14 +62,14 @@ namespace TrionicCANLib.CAN
             CANMessage canMessage = new CANMessage();
             string rxMessage = string.Empty;
             
-            Console.WriteLine("readMessages started");
+            logger.Trace("readMessages started");
             while (true)
             {
                 lock (m_synchObject)
                 {
                     if (m_endThread)
                     {
-                        Console.WriteLine("readMessages ended");
+                        logger.Trace("readMessages ended");
                         return;
                     }
                 }
@@ -97,7 +97,7 @@ namespace TrionicCANLib.CAN
                             lock (m_listeners)
                             {
                                 logger.Trace(String.Format("rx: {0:X3} {1:X1} {2:X16}", canMessage.getID(), canMessage.getLength(), canMessage.getData()));
-                                //Console.WriteLine("MSG: " + rxMessage);
+                                //logger.Trace("MSG: " + rxMessage);
                                 foreach (ICANListener listener in m_listeners)
                                 {
                                     listener.handleMessage(canMessage);
@@ -108,7 +108,7 @@ namespace TrionicCANLib.CAN
                 }
                 catch (Exception)
                 {
-                    Console.WriteLine("MSG: " + rxMessage);
+                    logger.Trace("MSG: " + rxMessage);
                 }
             }
         }
@@ -134,7 +134,7 @@ namespace TrionicCANLib.CAN
             {
                 logger.Trace(String.Format("tx: {0:X3} {1:X1} {2:X16}", a_message.getID(), a_message.getLength(), a_message.getData()));
                 m_serialPort.Write(sendString);
-                //Console.WriteLine("TX: " + sendString);
+                //logger.Trace("TX: " + sendString);
             }
 
             // bitrate = 38400bps -> 3840 bytes per second
@@ -175,7 +175,7 @@ namespace TrionicCANLib.CAN
             if (port != null)
             {
                 // only check this comport
-                Console.WriteLine("Opening com: " + port);
+                logger.Trace("Opening com: " + port);
 
                 if (m_serialPort.IsOpen)
                     m_serialPort.Close();
@@ -207,12 +207,12 @@ namespace TrionicCANLib.CAN
                     try
                     {
                         m_serialPort.ReadLine();
-                        Console.WriteLine("Connected to CAN at 47,619 speed");
+                        logger.Trace("Connected to CAN at 47,619 speed");
                         CastInformationEvent("Connected to CAN I-BUS using " + port);
 
                         if (m_readThread != null)
                         {
-                            Console.WriteLine(m_readThread.ThreadState.ToString());
+                            logger.Trace(m_readThread.ThreadState.ToString());
                         }
                         m_readThread = new Thread(readMessages) { Name = "Just4TrionicDevice.m_readThread" };
                         m_endThread = false; // reset for next tries :)
@@ -234,7 +234,7 @@ namespace TrionicCANLib.CAN
                     }
                     catch (Exception)
                     {
-                        Console.WriteLine("Unable to connect to the I-BUS");
+                        logger.Trace("Unable to connect to the I-BUS");
                     }
                 }
 
@@ -245,12 +245,12 @@ namespace TrionicCANLib.CAN
                 try
                 {
                     m_serialPort.ReadLine();
-                    Console.WriteLine("Connected to CAN at 500 kbits speed");
+                    logger.Trace("Connected to CAN at 500 kbits speed");
                     CastInformationEvent("Connected to CAN P-BUS using " + port);
 
                     if (m_readThread != null)
                     {
-                        Console.WriteLine(m_readThread.ThreadState.ToString());
+                        logger.Trace(m_readThread.ThreadState.ToString());
                     }
 
                     m_readThread = new Thread(readMessages) { Name = "Just4TrionicDevice.m_readThread" };
@@ -273,7 +273,7 @@ namespace TrionicCANLib.CAN
                 }
                 catch (Exception)
                 {
-                    Console.WriteLine("Unable to connect to the P-BUS"); 
+                    logger.Trace("Unable to connect to the P-BUS"); 
                 }
 
                 CastInformationEvent("Oh dear :-( Just4Trionic cannot connect to a CAN bus.");

--- a/TrionicCANLib/CAN/Just4TrionicDevice.cs
+++ b/TrionicCANLib/CAN/Just4TrionicDevice.cs
@@ -62,14 +62,14 @@ namespace TrionicCANLib.CAN
             CANMessage canMessage = new CANMessage();
             string rxMessage = string.Empty;
             
-            logger.Trace("readMessages started");
+            logger.Debug("readMessages started");
             while (true)
             {
                 lock (m_synchObject)
                 {
                     if (m_endThread)
                     {
-                        logger.Trace("readMessages ended");
+                        logger.Debug("readMessages ended");
                         return;
                     }
                 }
@@ -96,8 +96,8 @@ namespace TrionicCANLib.CAN
 
                             lock (m_listeners)
                             {
-                                logger.Trace(String.Format("rx: {0:X3} {1:X1} {2:X16}", canMessage.getID(), canMessage.getLength(), canMessage.getData()));
-                                //logger.Trace("MSG: " + rxMessage);
+                                logger.Debug(String.Format("rx: {0:X3} {1:X1} {2:X16}", canMessage.getID(), canMessage.getLength(), canMessage.getData()));
+                                //logger.Debug("MSG: " + rxMessage);
                                 foreach (ICANListener listener in m_listeners)
                                 {
                                     listener.handleMessage(canMessage);
@@ -108,7 +108,7 @@ namespace TrionicCANLib.CAN
                 }
                 catch (Exception)
                 {
-                    logger.Trace("MSG: " + rxMessage);
+                    logger.Debug("MSG: " + rxMessage);
                 }
             }
         }
@@ -132,9 +132,9 @@ namespace TrionicCANLib.CAN
             sendString += "\r";
             if (m_serialPort.IsOpen)
             {
-                logger.Trace(String.Format("tx: {0:X3} {1:X1} {2:X16}", a_message.getID(), a_message.getLength(), a_message.getData()));
+                logger.Debug(String.Format("tx: {0:X3} {1:X1} {2:X16}", a_message.getID(), a_message.getLength(), a_message.getData()));
                 m_serialPort.Write(sendString);
-                //logger.Trace("TX: " + sendString);
+                //logger.Debug("TX: " + sendString);
             }
 
             // bitrate = 38400bps -> 3840 bytes per second
@@ -175,7 +175,7 @@ namespace TrionicCANLib.CAN
             if (port != null)
             {
                 // only check this comport
-                logger.Trace("Opening com: " + port);
+                logger.Debug("Opening com: " + port);
 
                 if (m_serialPort.IsOpen)
                     m_serialPort.Close();
@@ -207,12 +207,12 @@ namespace TrionicCANLib.CAN
                     try
                     {
                         m_serialPort.ReadLine();
-                        logger.Trace("Connected to CAN at 47,619 speed");
+                        logger.Debug("Connected to CAN at 47,619 speed");
                         CastInformationEvent("Connected to CAN I-BUS using " + port);
 
                         if (m_readThread != null)
                         {
-                            logger.Trace(m_readThread.ThreadState.ToString());
+                            logger.Debug(m_readThread.ThreadState.ToString());
                         }
                         m_readThread = new Thread(readMessages) { Name = "Just4TrionicDevice.m_readThread" };
                         m_endThread = false; // reset for next tries :)
@@ -234,7 +234,7 @@ namespace TrionicCANLib.CAN
                     }
                     catch (Exception)
                     {
-                        logger.Trace("Unable to connect to the I-BUS");
+                        logger.Debug("Unable to connect to the I-BUS");
                     }
                 }
 
@@ -245,12 +245,12 @@ namespace TrionicCANLib.CAN
                 try
                 {
                     m_serialPort.ReadLine();
-                    logger.Trace("Connected to CAN at 500 kbits speed");
+                    logger.Debug("Connected to CAN at 500 kbits speed");
                     CastInformationEvent("Connected to CAN P-BUS using " + port);
 
                     if (m_readThread != null)
                     {
-                        logger.Trace(m_readThread.ThreadState.ToString());
+                        logger.Debug(m_readThread.ThreadState.ToString());
                     }
 
                     m_readThread = new Thread(readMessages) { Name = "Just4TrionicDevice.m_readThread" };
@@ -273,7 +273,7 @@ namespace TrionicCANLib.CAN
                 }
                 catch (Exception)
                 {
-                    logger.Trace("Unable to connect to the P-BUS"); 
+                    logger.Debug("Unable to connect to the P-BUS"); 
                 }
 
                 CastInformationEvent("Oh dear :-( Just4Trionic cannot connect to a CAN bus.");

--- a/TrionicCANLib/CAN/KvaserCANDevice.cs
+++ b/TrionicCANLib/CAN/KvaserCANDevice.cs
@@ -130,7 +130,7 @@ namespace TrionicCANLib.CAN
                             canMessage.setCanData(msg, (byte)dlc);
                             lock (m_listeners)
                             {
-                                logger.Trace(string.Format("rx: {0:X3} {1:X16}", canMessage.getID(), canMessage.getData()));
+                                logger.Debug(string.Format("rx: {0:X3} {1:X16}", canMessage.getID(), canMessage.getData()));
                                 foreach (ICANListener listener in m_listeners)
                                 {
                                     listener.handleMessage(canMessage);
@@ -325,12 +325,12 @@ namespace TrionicCANLib.CAN
 
             if (writeStatus == Canlib.canStatus.canOK)
             {
-                logger.Trace(String.Format("tx: {0:X3} {1:X16}", a_message.getID(), a_message.getData()));
+                logger.Debug(String.Format("tx: {0:X3} {1:X16}", a_message.getID(), a_message.getData()));
                 return true;
             }
             else
             {
-                logger.Trace(String.Format("tx: {0:X3} {1:X16} failed {2}", a_message.getID(), a_message.getData(), writeStatus));
+                logger.Debug(String.Format("tx: {0:X3} {1:X16} failed {2}", a_message.getID(), a_message.getData(), writeStatus));
                 return false;
             }
         }

--- a/TrionicCANLib/CAN/LPCCANDevice.cs
+++ b/TrionicCANLib/CAN/LPCCANDevice.cs
@@ -300,12 +300,12 @@ public class LPCCANDevice : ICANDevice
             frame.is_remote = 0;
 
             combi.CAN_SendMessage(ref frame);
-            logger.Trace("tx: " + msg.getID().ToString("X3") + " " + msg.getData().ToString("X16"));
+            logger.Debug("tx: " + msg.getID().ToString("X3") + " " + msg.getData().ToString("X16"));
             return true;
         }
         catch (Exception e)
         {
-            logger.Trace("tx: " + msg.getID().ToString("X3") + " " + msg.getData().ToString("X16") + " failed" + e.Message);
+            logger.Debug("tx: " + msg.getID().ToString("X3") + " " + msg.getData().ToString("X16") + " failed" + e.Message);
             return false;
         }
     }
@@ -409,7 +409,7 @@ public class LPCCANDevice : ICANDevice
             // receive messages
             if (combi.CAN_GetMessage(ref frame, 1000))
             {
-                logger.Trace("rx: " + frame.id.ToString("X3") + " " + frame.data.ToString("X16"));
+                logger.Debug("rx: " + frame.id.ToString("X3") + " " + frame.data.ToString("X16"));
                 if (acceptMessageId(frame.id))
                 {
                     // convert message

--- a/TrionicCANLib/ITrionic.cs
+++ b/TrionicCANLib/ITrionic.cs
@@ -142,7 +142,7 @@ namespace TrionicCANLib.API
 
         protected void CastInfoEvent(string info, ActivityType type)
         {
-            Console.WriteLine(info);
+            logger.Trace(info);
             if (onCanInfo != null)
             {
                 onCanInfo(this, new CanInfoEventArgs(info, type));
@@ -151,7 +151,7 @@ namespace TrionicCANLib.API
 
         protected void CastFrameEvent(CANMessage message)
         {
-            Console.WriteLine(message);
+            logger.Trace(message);
             if (onCanFrame != null)
             {
                 onCanFrame(this, new CanFrameEventArgs(message));

--- a/TrionicCANLib/ITrionic.cs
+++ b/TrionicCANLib/ITrionic.cs
@@ -142,7 +142,7 @@ namespace TrionicCANLib.API
 
         protected void CastInfoEvent(string info, ActivityType type)
         {
-            logger.Trace(info);
+            logger.Debug(info);
             if (onCanInfo != null)
             {
                 onCanInfo(this, new CanInfoEventArgs(info, type));
@@ -151,7 +151,7 @@ namespace TrionicCANLib.API
 
         protected void CastFrameEvent(CANMessage message)
         {
-            logger.Trace(message);
+            logger.Debug(message);
             if (onCanFrame != null)
             {
                 onCanFrame(this, new CanFrameEventArgs(message));

--- a/TrionicCANLib/KWP/ELM327Device.cs
+++ b/TrionicCANLib/KWP/ELM327Device.cs
@@ -280,7 +280,7 @@ namespace TrionicCANLib.KWP
                                 {
                                     string elmVersion = m_serialPort.ReadExisting();
                                     //AddToSerialTrace("elmVersion:" + elmVersion);
-                                    logger.Trace("elmVersion: " + elmVersion);
+                                    logger.Debug("elmVersion: " + elmVersion);
                                     if (elmVersion.Length > 5)
                                     {
                                         gotVersion = true;
@@ -332,7 +332,7 @@ namespace TrionicCANLib.KWP
             {
                 foreach (var speed in speeds)
                 {
-                    Console.Out.WriteLine("Try speed:" + speed);
+                    logger.Debug("Try speed:" + speed);
                     //if (m_serialPort.IsOpen)
                     m_serialPort.Close();
                     m_serialPort.BaudRate = speed;
@@ -347,7 +347,7 @@ namespace TrionicCANLib.KWP
                         WriteToSerialWithTrace("ATI\r"); //need to send 2 times for some reason...
                         Thread.Sleep(50);
                         string reply = m_serialPort.ReadExisting();
-                        Console.Out.WriteLine("Result:" + reply);
+                        logger.Debug("Result:" + reply);
                         bool success = !string.IsNullOrEmpty(reply) && reply.Contains("ELM327");
                         if (success)
                         {
@@ -366,7 +366,7 @@ namespace TrionicCANLib.KWP
                         }
                         else
                         {
-                            Console.Out.WriteLine("Failed");
+                            logger.Debug("Failed");
                             m_serialPort.Close();
                         }
                     }

--- a/TrionicCANLib/KWP/ELM327Device.cs
+++ b/TrionicCANLib/KWP/ELM327Device.cs
@@ -4,12 +4,13 @@ using System.Text;
 using System.IO.Ports;
 using System.Threading;
 using TrionicCANLib.CAN;
+using NLog;
 
 namespace TrionicCANLib.KWP
 {
     class ELM327Device : IKWPDevice
     {
-
+        private static Logger logger = LogManager.GetCurrentClassLogger();
         bool m_deviceIsOpen = false;
         SerialPort m_serialPort = new SerialPort();
 
@@ -279,7 +280,7 @@ namespace TrionicCANLib.KWP
                                 {
                                     string elmVersion = m_serialPort.ReadExisting();
                                     //AddToSerialTrace("elmVersion:" + elmVersion);
-                                    Console.WriteLine("elmVersion: " + elmVersion);
+                                    logger.Trace("elmVersion: " + elmVersion);
                                     if (elmVersion.Length > 5)
                                     {
                                         gotVersion = true;

--- a/TrionicCANLib/KWP/KWPCANDevice.cs
+++ b/TrionicCANLib/KWP/KWPCANDevice.cs
@@ -118,14 +118,14 @@ namespace TrionicCANLib.KWP
             {
                 lock (m_lockObject)
                 {
-                    logger.Trace("******* KWPCANDevice: m_CanDevice set");
+                    logger.Debug("******* KWPCANDevice: m_CanDevice set");
 
                     m_canDevice = a_canDevice;
                 }
             }
             else
             {
-                logger.Trace("KWPCANDevice, candevice was already set");
+                logger.Debug("KWPCANDevice, candevice was already set");
             }
         }
 
@@ -135,23 +135,23 @@ namespace TrionicCANLib.KWP
         /// <returns>True if the device was opened, otherwise false.</returns>
         public override bool open()
         {
-            logger.Trace("******* KWPCANDevice: Opening KWPCANDevice");
+            logger.Debug("******* KWPCANDevice: Opening KWPCANDevice");
 
             bool retVal = false;
-            logger.Trace("Opening m_canDevice");
+            logger.Debug("Opening m_canDevice");
             lock (m_lockObject)
             {
-                logger.Trace("Lock passed: Opening m_canDevice");
+                logger.Debug("Lock passed: Opening m_canDevice");
                 if (m_canDevice.open() == OpenResult.OK)
                 {
-                    logger.Trace("Adding listener");
+                    logger.Debug("Adding listener");
                     m_canDevice.addListener(m_kwpCanListener);
                     retVal = true;
                 }
                 else
                     retVal = false;
             }
-            logger.Trace("return value = " + retVal.ToString());
+            logger.Debug("return value = " + retVal.ToString());
             return retVal;
         }
 
@@ -178,7 +178,7 @@ namespace TrionicCANLib.KWP
         /// <returns>True if the device was closed, otherwise false.</returns>
         public override bool close()
         {
-            logger.Trace("******* KWPCANDevice: Closing KWPCANDevice");
+            logger.Debug("******* KWPCANDevice: Closing KWPCANDevice");
 
             bool retVal = false;
             lock (m_lockObject)

--- a/TrionicCANLib/KWP/KWPCANDevice.cs
+++ b/TrionicCANLib/KWP/KWPCANDevice.cs
@@ -70,7 +70,7 @@ namespace TrionicCANLib.KWP
         private ICANDevice m_canDevice;
         KWPCANListener m_kwpCanListener = new KWPCANListener();
         const int timeoutPeriod = 1000; // if timeout <GS-11022010> changed from 1000 to 250 to not intefere with the keepalive timer
-        private Logger logger = LogManager.GetCurrentClassLogger();
+        private static Logger logger = LogManager.GetCurrentClassLogger();
 
         private bool m_EnableLog = false;
 
@@ -118,14 +118,14 @@ namespace TrionicCANLib.KWP
             {
                 lock (m_lockObject)
                 {
-                    Console.WriteLine("******* KWPCANDevice: m_CanDevice set");
+                    logger.Trace("******* KWPCANDevice: m_CanDevice set");
 
                     m_canDevice = a_canDevice;
                 }
             }
             else
             {
-                Console.WriteLine("KWPCANDevice, candevice was already set");
+                logger.Trace("KWPCANDevice, candevice was already set");
             }
         }
 
@@ -135,23 +135,23 @@ namespace TrionicCANLib.KWP
         /// <returns>True if the device was opened, otherwise false.</returns>
         public override bool open()
         {
-            Console.WriteLine("******* KWPCANDevice: Opening KWPCANDevice");
+            logger.Trace("******* KWPCANDevice: Opening KWPCANDevice");
 
             bool retVal = false;
-            Console.WriteLine("Opening m_canDevice");
+            logger.Trace("Opening m_canDevice");
             lock (m_lockObject)
             {
-                Console.WriteLine("Lock passed: Opening m_canDevice");
+                logger.Trace("Lock passed: Opening m_canDevice");
                 if (m_canDevice.open() == OpenResult.OK)
                 {
-                    Console.WriteLine("Adding listener");
+                    logger.Trace("Adding listener");
                     m_canDevice.addListener(m_kwpCanListener);
                     retVal = true;
                 }
                 else
                     retVal = false;
             }
-            Console.WriteLine("return value = " + retVal.ToString());
+            logger.Trace("return value = " + retVal.ToString());
             return retVal;
         }
 
@@ -178,7 +178,7 @@ namespace TrionicCANLib.KWP
         /// <returns>True if the device was closed, otherwise false.</returns>
         public override bool close()
         {
-            Console.WriteLine("******* KWPCANDevice: Closing KWPCANDevice");
+            logger.Trace("******* KWPCANDevice: Closing KWPCANDevice");
 
             bool retVal = false;
             lock (m_lockObject)
@@ -266,6 +266,7 @@ namespace TrionicCANLib.KWP
                 row = 0;
                 if (nrOfRows == 0)
                     throw new Exception("Wrong nr of rows");
+
                 //Assume that no KWP reply contains more than 0x200 bytes
                 byte[] reply = new byte[0x200];
                 reply = collectReply(reply, response.getData(), row);
@@ -343,23 +344,27 @@ namespace TrionicCANLib.KWP
         {
             if (a_row > nrOfRowsToSend(a_data))
                 throw new Exception("Message nr out of index");
+            
             ulong result = 0;
             uint i = 0;
             if(nrOfRowsToSend(a_data) - a_row - 1 == 0)
                 result = setCanData(result, (byte)(0x40 | a_row), i++);
             else
                 result = setCanData(result, (byte)a_row, i++);
+            
             result = setCanData(result, (byte)0xA1, i++);
             uint j;
             if (nrOfRowsToSend(a_data) - a_row - 1 == 0)
                 j = 0;
             else
                 j = ((nrOfRowsToSend(a_data) - a_row  - 1)* 6);
+            
             int nrOfBytesToCopy;
             if (a_data.Length - j < 6)
                 nrOfBytesToCopy = (int)(a_data.Length - j);
             else
                 nrOfBytesToCopy = 6;
+            
             for (int k = 0; k < nrOfBytesToCopy; i++, j++, k++)
                 result = setCanData(result, (byte)a_data[j], i);
             return result;

--- a/TrionicCANLib/KWP/KWPHandler.cs
+++ b/TrionicCANLib/KWP/KWPHandler.cs
@@ -43,14 +43,14 @@ namespace TrionicCANLib.KWP
         /// <param name="a_kwpDevice">IKWPDevice to be used by KWPHandler.</param>
         public static void setKWPDevice(IKWPDevice a_kwpDevice)
         {
-            logger.Trace("******* KWPHandler: KWP device set");
+            logger.Debug("******* KWPHandler: KWP device set");
             m_kwpDevice = a_kwpDevice;
         }
 
         public static KWPHandler getInstance()
         {
             if (m_kwpDevice == null)
-                logger.Trace("KWPDevice not set.");
+                logger.Debug("KWPDevice not set.");
             if (m_instance == null)
                 m_instance = new KWPHandler();
             return m_instance;
@@ -90,7 +90,7 @@ namespace TrionicCANLib.KWP
         {
             if (m_kwpDevice.isOpen() && !m_suspendAlivePolling)
             {
-                logger.Trace("Sending keep alive");
+                logger.Debug("Sending keep alive");
                 sendUnknownRequest();
             }
         }
@@ -111,7 +111,7 @@ namespace TrionicCANLib.KWP
         /// <returns>true on success, otherwise false.</returns>
         public bool openDevice()
         {
-            logger.Trace("******* KWPHandler: Opening kwpDevice");
+            logger.Debug("******* KWPHandler: Opening kwpDevice");
 
             return m_kwpDevice.open();
         }
@@ -122,7 +122,7 @@ namespace TrionicCANLib.KWP
         /// <returns>true on success, otherwise false.</returns>
         public bool closeDevice()
         {
-            logger.Trace("******* KWPHandler: Closing kwpDevice");
+            logger.Debug("******* KWPHandler: Closing kwpDevice");
 
             if(m_kwpDevice != null)
                 return m_kwpDevice.close();
@@ -155,29 +155,29 @@ namespace TrionicCANLib.KWP
         // This function work well to reset the T7 ECU, but doing so in car will cause limphome of throttlebody. 
         public bool ResetECU()
         {
-            logger.Trace("ResetECU");
+            logger.Debug("ResetECU");
             KWPReply reply = new KWPReply();
             KWPResult result;
             byte[] data = new byte[1];
             data[0] = (byte)0x00;
             KWPRequest req = new KWPRequest(0x11, 0x01, data);
-            logger.Trace(req.ToString());
+            logger.Debug(req.ToString());
             result = sendRequest(req, out reply);
             if (reply.getMode() == 0x51)
             {
-                logger.Trace("Reset Success: " + reply.ToString());
+                logger.Debug("Reset Success: " + reply.ToString());
                 return true;
             }
             else if (reply.getMode() == 0x7F)
             {
-                logger.Trace("Reset Failed: " + reply.ToString());
+                logger.Debug("Reset Failed: " + reply.ToString());
             }
             return false;
         }
 
         public bool ReadFreezeFrameData(uint frameNumber)
         {
-            logger.Trace("ReadFreezeFrameData");
+            logger.Debug("ReadFreezeFrameData");
             KWPReply reply = new KWPReply();
             KWPResult result;
             byte[] data = new byte[1];
@@ -185,16 +185,16 @@ namespace TrionicCANLib.KWP
             //data[1] = (byte)0x00;
             //data[2] = (byte)0x00;
             KWPRequest req = new KWPRequest(0x12, Convert.ToByte(frameNumber), data);
-            logger.Trace(req.ToString());
+            logger.Debug(req.ToString());
             result = sendRequest(req, out reply);
-            logger.Trace(reply.ToString());
+            logger.Debug(reply.ToString());
             return true;
         }
 
         public bool ReadDTCCodes(out List<string> list)
         {
             list = new List<string>();
-            logger.Trace("ReadDTCCodes");
+            logger.Debug("ReadDTCCodes");
             KWPReply reply = new KWPReply();
             KWPResult result;
             byte[] data = new byte[2];
@@ -211,9 +211,9 @@ namespace TrionicCANLib.KWP
             // 1 Current code - present at time of request
             // 0 Maturing/intermittent code - insufficient data to consider as a malfunction
             KWPRequest req = new KWPRequest(0x18 , 0x02); // Request Diagnostic Trouble Codes by Status
-            logger.Trace(req.ToString());
+            logger.Debug(req.ToString());
             result = sendRequest(req, out reply);
-            logger.Trace(reply.ToString());
+            logger.Debug(reply.ToString());
             // J2190
             // Multiple Mode $58 response messages may be reported to a single request, depending on the number of diagnostic 
             // trouble codes stored in the module. Each response message will report up to three DTCs for
@@ -224,7 +224,7 @@ namespace TrionicCANLib.KWP
             {
                 if (reply.getPid() == 0x00)
                 {
-                    logger.Trace("No DTC's");
+                    logger.Debug("No DTC's");
                     list.Add("No DTC's");
                     return true;
                 }
@@ -270,7 +270,7 @@ namespace TrionicCANLib.KWP
 
         public bool ClearDTCCode(int dtccode)
         {
-            logger.Trace("ClearDTCCode: " + dtccode.ToString("X4"));
+            logger.Debug("ClearDTCCode: " + dtccode.ToString("X4"));
             KWPReply reply = new KWPReply();
             KWPResult result;
             byte[] data = new byte[1];
@@ -278,15 +278,15 @@ namespace TrionicCANLib.KWP
             //data[1] = (byte)0xFF;
             //data[2] = (byte)0x00;
             KWPRequest req = new KWPRequest(0x14, (byte)(dtccode >> 8), data);
-            logger.Trace(req.ToString());
+            logger.Debug(req.ToString());
             result = sendRequest(req, out reply);
-            logger.Trace(reply.ToString());
+            logger.Debug(reply.ToString());
             return true;
         }
 
         public bool ClearDTCCodes()
         {
-            logger.Trace("ClearDTCCodes");
+            logger.Debug("ClearDTCCodes");
             KWPReply reply = new KWPReply();
             KWPResult result;
             byte[] data = new byte[1];
@@ -294,9 +294,9 @@ namespace TrionicCANLib.KWP
             //data[1] = (byte)0xFF;
             //data[2] = (byte)0x00;
             KWPRequest req = new KWPRequest(0x14, 0xFF, data);
-            logger.Trace(req.ToString());
+            logger.Debug(req.ToString());
             result = sendRequest(req, out reply);
-            logger.Trace(reply.ToString());
+            logger.Debug(reply.ToString());
             return true;
         }
 
@@ -308,16 +308,16 @@ namespace TrionicCANLib.KWP
         /// <returns>true if sequrity access was granted, otherwise false</returns>
         private bool requestSequrityAccessLevel(uint a_method)
         {
-            logger.Trace("requestSequrityAccessLevel: " + a_method.ToString());
+            logger.Debug("requestSequrityAccessLevel: " + a_method.ToString());
             KWPReply reply = new KWPReply();
             KWPResult result;
             byte[] seed = new byte[2];
             byte[] key = new byte[2];
             // Send a seed request.
             KWPRequest requestForKey = new KWPRequest(0x27, 0x05);
-            logger.Trace("requestSequrityAccessLevel " + a_method.ToString() +  " request for key: " + requestForKey.ToString());
+            logger.Debug("requestSequrityAccessLevel " + a_method.ToString() +  " request for key: " + requestForKey.ToString());
             result = sendRequest(requestForKey, out reply);
-            logger.Trace("requestSequrityAccessLevel " + a_method.ToString() + " request for key result: " + reply.ToString());
+            logger.Debug("requestSequrityAccessLevel " + a_method.ToString() + " request for key result: " + reply.ToString());
 
             if (result != KWPResult.OK)
                 return false;
@@ -331,25 +331,25 @@ namespace TrionicCANLib.KWP
                 key = calculateKey(seed, 1);
             // Send key reply.
             KWPRequest sendKeyRequest = new KWPRequest(0x27, 0x06, key);
-            logger.Trace("requestSequrityAccessLevel " + a_method.ToString() +  " send Key request: " + sendKeyRequest.ToString());
+            logger.Debug("requestSequrityAccessLevel " + a_method.ToString() +  " send Key request: " + sendKeyRequest.ToString());
             result = sendRequest(sendKeyRequest, out reply);
-            logger.Trace("requestSequrityAccessLevel " + a_method.ToString() + " send Key reply: " + reply.ToString());
+            logger.Debug("requestSequrityAccessLevel " + a_method.ToString() + " send Key reply: " + reply.ToString());
             if (result != KWPResult.OK)
             {
-                logger.Trace("Security access request was not send");
+                logger.Debug("Security access request was not send");
                 return false;
             }
 
             //Check if sequrity was granted.
-            logger.Trace("Mode: " + reply.getMode().ToString("X2"));
-            logger.Trace("Data: " + reply.getData()[0].ToString("X2"));
+            logger.Debug("Mode: " + reply.getMode().ToString("X2"));
+            logger.Debug("Data: " + reply.getData()[0].ToString("X2"));
             if ((reply.getMode() == 0x67) && (reply.getData()[0] == 0x34)) // WAS [0]
             {
-                logger.Trace("Security access granted: " + a_method.ToString());
+                logger.Debug("Security access granted: " + a_method.ToString());
                 return true;
             }
 
-            logger.Trace("Security access was not granted: " + reply.ToString());
+            logger.Debug("Security access was not granted: " + reply.ToString());
             return false;
         }
 
@@ -360,7 +360,7 @@ namespace TrionicCANLib.KWP
         /// <returns>KWPResult</returns>
         public KWPResult getVIN(out string r_vin)
         {
-            logger.Trace("getVIN");
+            logger.Debug("getVIN");
 
             KWPReply reply = new KWPReply();
             KWPResult result;
@@ -450,7 +450,7 @@ namespace TrionicCANLib.KWP
             }
             else if (reply.getMode() == 0x7F && reply.getPid() == 0x21 && reply.getLength() == 3)
             {
-                logger.Trace(TranslateErrorCode(reply.getData()[0]));
+                logger.Debug(TranslateErrorCode(reply.getData()[0]));
             }
             r_level = 0;
             return KWPResult.NOK;
@@ -476,7 +476,7 @@ namespace TrionicCANLib.KWP
             }
             else if(reply.getMode() == 0x7F && reply.getPid() == 0x3B && reply.getLength() == 3)
             {
-                logger.Trace(TranslateErrorCode(reply.getData()[0]));
+                logger.Debug(TranslateErrorCode(reply.getData()[0]));
             }
 
             return KWPResult.NOK;
@@ -489,7 +489,7 @@ namespace TrionicCANLib.KWP
         /// <returns>KWPResult</returns>
         public KWPResult getImmo(out string r_immo)
         {
-            logger.Trace("getImmo");
+            logger.Debug("getImmo");
 
             KWPReply reply = new KWPReply();
             KWPResult result;
@@ -508,7 +508,7 @@ namespace TrionicCANLib.KWP
         /// <returns>KWPResult</returns>
         public KWPResult getSymbolTableOffset(out UInt16 r_offset)
         {
-            logger.Trace("getSymbolTableOffset");
+            logger.Debug("getSymbolTableOffset");
 
             KWPReply reply = new KWPReply();
             KWPResult result;
@@ -527,7 +527,7 @@ namespace TrionicCANLib.KWP
         /// <returns>KWPResult</returns>
         public KWPResult getSwPartNumber(out string r_swPartNo)
         {
-            logger.Trace("getSwPartNumber");
+            logger.Debug("getSwPartNumber");
 
             KWPReply reply = new KWPReply();
             KWPResult result;
@@ -543,7 +543,7 @@ namespace TrionicCANLib.KWP
         /// <returns>KWPResult</returns>
         public KWPResult getSwVersion(out string r_swVersion)
         {
-            logger.Trace("getSwVersion");
+            logger.Debug("getSwVersion");
 
             KWPReply reply = new KWPReply();
             KWPResult result;
@@ -562,7 +562,7 @@ namespace TrionicCANLib.KWP
         /// <returns>KWPResult</returns>
         public KWPResult getSwVersionFromDR51(out string r_swVersion)
         {
-            logger.Trace("getSwVersionFromDR51");
+            logger.Debug("getSwVersionFromDR51");
 
             KWPReply reply = new KWPReply();
             KWPResult result;
@@ -581,7 +581,7 @@ namespace TrionicCANLib.KWP
         /// <returns>KWPResult</returns>
         public KWPResult getEngineType(out string r_swVersion)
         {
-            logger.Trace("getEngineType");
+            logger.Debug("getEngineType");
 
             KWPReply reply = new KWPReply();
             KWPResult result;
@@ -604,7 +604,7 @@ namespace TrionicCANLib.KWP
             6 stop address (low byte)
             */
             Int32 StopAddress = StartAddress + Length;
-            logger.Trace("sendEraseRequest");
+            logger.Debug("sendEraseRequest");
 
             KWPReply reply = new KWPReply();
             KWPReply reply2 = new KWPReply();
@@ -629,18 +629,18 @@ namespace TrionicCANLib.KWP
             KWPRequest req = new KWPRequest(0x31, 0x50, a_data);
             
             result = sendRequest(req, out reply);
-            logger.Trace("Erase(1) " + reply.ToString());
+            logger.Debug("Erase(1) " + reply.ToString());
             /*if (result != KWPResult.OK)
                 return result;
             System.Threading.Thread.Sleep(10000);
             result = sendRequest(new KWPRequest(0x31, 0x53, a_data), out reply);
-            logger.Trace("Erase(2:" + i.ToString() + ") " + reply.ToString());
+            logger.Debug("Erase(2:" + i.ToString() + ") " + reply.ToString());
             */
             if (result != KWPResult.OK)
                 return result;
 
             result = sendRequest(new KWPRequest(0x3E, 0x50), out reply2); // tester present???
-            logger.Trace("reply on exit " + reply2.ToString());
+            logger.Debug("reply on exit " + reply2.ToString());
 
             return result;
         }
@@ -652,7 +652,7 @@ namespace TrionicCANLib.KWP
         /// <returns>KWPResult</returns>
         public KWPResult sendEraseRequest()
         {
-            logger.Trace("sendEraseRequest");
+            logger.Debug("sendEraseRequest");
 
             KWPReply reply = new KWPReply();
             KWPReply reply2 = new KWPReply();
@@ -664,14 +664,14 @@ namespace TrionicCANLib.KWP
             //PID = 0x52
             //Expected result is 0x71
             result = sendRequest(new KWPRequest(0x31, 0x52), out reply);
-            logger.Trace("Erase(1) " + reply.ToString());
+            logger.Debug("Erase(1) " + reply.ToString());
             if (result != KWPResult.OK)
                 return result;
             while (reply.getMode() != 0x71) 
             {
                 System.Threading.Thread.Sleep(1000);
                 result = sendRequest(new KWPRequest(0x31, 0x52), out reply);
-                logger.Trace("Erase(2:" + i.ToString() + ") " + reply.ToString());
+                logger.Debug("Erase(2:" + i.ToString() + ") " + reply.ToString());
                 if (i++ > 15) return KWPResult.Timeout;
             }
             if (result != KWPResult.OK) 
@@ -683,14 +683,14 @@ namespace TrionicCANLib.KWP
             //Expected result is 0x71
             i = 0;
             result = sendRequest(new KWPRequest(0x31, 0x53), out reply2);
-            logger.Trace("Erase(3) " + reply2.ToString());
+            logger.Debug("Erase(3) " + reply2.ToString());
             if (result != KWPResult.OK)
                 return result;
             while (reply2.getMode() != 0x71)
             {
                 System.Threading.Thread.Sleep(1000);
                 result = sendRequest(new KWPRequest(0x31, 0x53), out reply2);
-                logger.Trace("Erase(4:" + i.ToString() + ") " + reply2.ToString());
+                logger.Debug("Erase(4:" + i.ToString() + ") " + reply2.ToString());
                 if (i++ > 20) return KWPResult.Timeout;
             }
 
@@ -698,7 +698,7 @@ namespace TrionicCANLib.KWP
             //Mode = 0x3E
             //Expected result is 0x7E
             result = sendRequest(new KWPRequest(0x3E, 0x53), out reply2);
-            logger.Trace("Erase(5) " + reply2.ToString());
+            logger.Debug("Erase(5) " + reply2.ToString());
 
             return result;
         }
@@ -712,7 +712,7 @@ namespace TrionicCANLib.KWP
         /// <returns>KWPResult</returns>
         public KWPResult sendWriteRequest(uint a_address, uint a_length)
         {
-            logger.Trace("sendWriteRequest");
+            logger.Debug("sendWriteRequest");
 
             KWPReply reply = new KWPReply();
             KWPResult result;
@@ -748,7 +748,7 @@ namespace TrionicCANLib.KWP
         /// <returns>KWPResult</returns>
         public KWPResult sendWriteDataRequest(byte[] a_data)
         {
-            logger.Trace("sendWriteDataRequest");
+            logger.Debug("sendWriteDataRequest");
 
             KWPReply reply = new KWPReply();
             KWPResult result;
@@ -772,7 +772,7 @@ namespace TrionicCANLib.KWP
         /// <returns>KWPResult</returns>
         public KWPResult sendDataTransferRequest(out byte[] a_data)
         {
-            logger.Trace("sendDataTransferRequest");
+            logger.Debug("sendDataTransferRequest");
 
             KWPReply reply = new KWPReply();
             KWPResult result;
@@ -797,8 +797,8 @@ namespace TrionicCANLib.KWP
         /// <returns>KWPResult</returns>
         public KWPResult sendUnknownRequest()
         {
-            logger.Trace("sendUnknownRequest");
-            //logger.Trace("sendUnknownRequest");
+            logger.Debug("sendUnknownRequest");
+            //logger.Debug("sendUnknownRequest");
             KWPReply reply = new KWPReply();
             KWPResult result;
 
@@ -821,7 +821,7 @@ namespace TrionicCANLib.KWP
         /// <returns>KWPResult</returns>
         public KWPResult sendReadSymbolMapRequest()
         {
-            logger.Trace("sendReadSymbolMapRequest");
+            logger.Debug("sendReadSymbolMapRequest");
 
             KWPReply reply = new KWPReply();
             KWPResult result;
@@ -847,7 +847,7 @@ namespace TrionicCANLib.KWP
         /// <returns>true on success, otherwise false</returns>
         public bool sendReadRequest(uint a_address, uint a_length, out byte[] data) 
         {
-            logger.Trace("sendReadRequest");
+            logger.Debug("sendReadRequest");
 
             KWPReply reply = new KWPReply();
             KWPResult result;
@@ -880,7 +880,7 @@ namespace TrionicCANLib.KWP
         /// <returns>true on success, otherwise false</returns>
         public bool sendReadRequest(uint a_address, uint a_length)
         {
-            logger.Trace("sendReadRequest");
+            logger.Debug("sendReadRequest");
 
             KWPReply reply = new KWPReply();
             KWPResult result;
@@ -908,7 +908,7 @@ namespace TrionicCANLib.KWP
         /// <returns></returns>
         public bool setSymbolRequest(uint a_symbolNumber)
         {
-            logger.Trace("setSymbolRequest");
+            logger.Debug("setSymbolRequest");
 
             KWPReply reply = new KWPReply();
             KWPResult result = KWPResult.Timeout;
@@ -929,7 +929,7 @@ namespace TrionicCANLib.KWP
                 if (reply.getLength() != 2)
                 {
                     result = KWPResult.Timeout;
-                    logger.Trace("Got wrong response on sendRequest in setSymbolRequest, len = " + reply.getLength().ToString("D2"));
+                    logger.Debug("Got wrong response on sendRequest in setSymbolRequest, len = " + reply.getLength().ToString("D2"));
                 }
             }
             if (result == KWPResult.OK)
@@ -938,8 +938,8 @@ namespace TrionicCANLib.KWP
             }
             else
             {
-                logger.Trace("setSymbolRequest timed out");
-                logger.Trace("setSymbolRequest timed out");
+                logger.Debug("setSymbolRequest timed out");
+                logger.Debug("setSymbolRequest timed out");
                 return false;
             }
         }
@@ -953,7 +953,7 @@ namespace TrionicCANLib.KWP
         /// <returns></returns>
         public bool writeSymbolRequestAddress(uint a_address, byte[] a_data)
         {
-            logger.Trace("writeSymbolRequest: " + a_address.ToString("X8") + "len: " + a_data.Length.ToString("X4"));
+            logger.Debug("writeSymbolRequest: " + a_address.ToString("X8") + "len: " + a_data.Length.ToString("X4"));
 
             KWPReply reply = new KWPReply();
             KWPResult result;
@@ -974,19 +974,19 @@ namespace TrionicCANLib.KWP
             {
                 requestString += b.ToString("X2") + " ";
             }
-            logger.Trace(requestString);
+            logger.Debug(requestString);
             // end dump to console
-            logger.Trace("SymbolNumberAndData length: " + symbolNumberAndData.Length.ToString("X8"));
+            logger.Debug("SymbolNumberAndData length: " + symbolNumberAndData.Length.ToString("X8"));
             KWPRequest t_request = new KWPRequest(0x3D, /*0x81, */symbolNumberAndData);
-            logger.Trace(t_request.ToString());
+            logger.Debug(t_request.ToString());
             result = sendRequest(t_request, out reply);
             if (result != KWPResult.OK)
             {
-                logger.Trace("Result != KWPResult.OK");
+                logger.Debug("Result != KWPResult.OK");
                 return false;
             }
-            logger.Trace("Result = " + reply.getData()[0].ToString("X2"));
-            logger.Trace("Result-total = " + reply.ToString());
+            logger.Debug("Result = " + reply.getData()[0].ToString("X2"));
+            logger.Debug("Result-total = " + reply.ToString());
             if (reply.getData()[0] == 0x7D)
             {
                 return true;
@@ -1006,7 +1006,7 @@ namespace TrionicCANLib.KWP
         /// <returns></returns>
         public bool writeSymbolRequest(uint a_symbolNumber, byte[] a_data)
         {
-            logger.Trace("writeSymbolRequest: " + a_symbolNumber.ToString());
+            logger.Debug("writeSymbolRequest: " + a_symbolNumber.ToString());
 
             KWPReply reply = new KWPReply();
             KWPResult result;
@@ -1028,19 +1028,19 @@ namespace TrionicCANLib.KWP
             {
                 requestString += b.ToString("X2") + " ";
             }
-            logger.Trace(requestString);
+            logger.Debug(requestString);
             // end dump to console
-            logger.Trace("SymbolNumberAndData length: " + symbolNumberAndData.Length.ToString("X8"));
+            logger.Debug("SymbolNumberAndData length: " + symbolNumberAndData.Length.ToString("X8"));
             KWPRequest t_request = new KWPRequest(0x3D, 0x80, symbolNumberAndData);
-            logger.Trace(t_request.ToString());
+            logger.Debug(t_request.ToString());
             result = sendRequest(t_request, out reply);
             if (result != KWPResult.OK)
             {
-                logger.Trace("Result != KWPResult.OK");
+                logger.Debug("Result != KWPResult.OK");
                 return false;
             }
-            logger.Trace("Result = " + reply.getData()[0].ToString("X2"));
-            logger.Trace("Resulttotal = " + reply.ToString());
+            logger.Debug("Result = " + reply.getData()[0].ToString("X2"));
+            logger.Debug("Resulttotal = " + reply.ToString());
             if (reply.getData()[0] == 0x7D)
             {
                 return true;
@@ -1060,7 +1060,7 @@ namespace TrionicCANLib.KWP
         /// <returns></returns>
         public bool writeSymbolRequestTest(uint a_symbolNumber, byte[] a_data, int idx)
         {
-            logger.Trace("writeSymbolRequest: " + a_symbolNumber.ToString());
+            logger.Debug("writeSymbolRequest: " + a_symbolNumber.ToString());
 
             KWPReply reply = new KWPReply();
             KWPResult result;
@@ -1082,18 +1082,18 @@ namespace TrionicCANLib.KWP
             {
                 requestString += b.ToString("X2") + " ";
             }
-            logger.Trace(requestString);
+            logger.Debug(requestString);
             // end dump to console
-            logger.Trace("SymbolNumberAndData length: " + symbolNumberAndData.Length.ToString("X8"));
+            logger.Debug("SymbolNumberAndData length: " + symbolNumberAndData.Length.ToString("X8"));
             KWPRequest t_request = new KWPRequest(0x3D, 0x80, symbolNumberAndData);
-            logger.Trace(t_request.ToString());
+            logger.Debug(t_request.ToString());
             result = sendRequest(t_request, out reply);
             if (result != KWPResult.OK)
             {
-                logger.Trace("Result != KWPResult.OK");
+                logger.Debug("Result != KWPResult.OK");
                 return false;
             }
-            logger.Trace("Result = " + reply.getData()[0].ToString("X2"));
+            logger.Debug("Result = " + reply.getData()[0].ToString("X2"));
             if (reply.getData()[0] == 0x7D)
             {
                 return true;
@@ -1111,7 +1111,7 @@ namespace TrionicCANLib.KWP
         /// <returns>true on success, otherwise false.</returns>
         public bool sendDataTransferExitRequest()
         {
-            logger.Trace("sendDataTransferExitRequest");
+            logger.Debug("sendDataTransferExitRequest");
 
             KWPReply reply = new KWPReply();
             KWPResult result;
@@ -1130,7 +1130,7 @@ namespace TrionicCANLib.KWP
         /// <returns></returns>
         public bool sendRequestDataByOffset(out byte[] r_data)
         {
-            logger.Trace("sendRequestDataByOffset");
+            logger.Debug("sendRequestDataByOffset");
 
             KWPReply reply = new KWPReply();
             KWPResult result;
@@ -1165,12 +1165,12 @@ namespace TrionicCANLib.KWP
         /// <returns>KWPResult</returns>
         private KWPResult sendRequest(KWPRequest a_request, out KWPReply a_reply)
         {
-            logger.Trace("sendRequest");
+            logger.Debug("sendRequest");
 
             KWPReply reply = new KWPReply();
             RequestResult result;
             a_reply = new KWPReply();
-            //logger.Trace("Checking KWP device open");
+            //logger.Debug("Checking KWP device open");
             if (!m_kwpDevice.isOpen())
                 return KWPResult.DeviceNotConnected;
 
@@ -1182,23 +1182,23 @@ namespace TrionicCANLib.KWP
 
             m_requestMutex.WaitOne();
 
-            logger.Trace(a_request.ToString());
+            logger.Debug(a_request.ToString());
             for (int retry = 0; retry < 3; retry++)
             {
                 result = m_kwpDevice.sendRequest(a_request, out reply);
                 a_reply = reply;
                 if (result == RequestResult.NoError)
                 {
-                    logger.Trace(reply.ToString());
-                    logger.Trace(""); // empty line
+                    logger.Debug(reply.ToString());
+                    logger.Debug(""); // empty line
 
                     m_requestMutex.ReleaseMutex();
                     return KWPResult.OK;
                 }
                 else
                 {
-                    logger.Trace("Error in KWPHandler::sendRequest: " + result.ToString() + " " + retry.ToString());
-                    logger.Trace("Error in KWPHandler::sendRequest: " + result.ToString() + " " + retry.ToString());
+                    logger.Debug("Error in KWPHandler::sendRequest: " + result.ToString() + " " + retry.ToString());
+                    logger.Debug("Error in KWPHandler::sendRequest: " + result.ToString() + " " + retry.ToString());
                 }
             }
             m_requestMutex.ReleaseMutex();
@@ -1215,12 +1215,12 @@ namespace TrionicCANLib.KWP
         {
             int _maxSendRetries = 3;
             KWPResult _kwpResult = KWPResult.Timeout;
-            logger.Trace("sendRequest");
+            logger.Debug("sendRequest");
             
             KWPReply reply = new KWPReply();
             RequestResult result;
             a_reply = new KWPReply();
-            //logger.Trace("Checking KWP device open");
+            //logger.Debug("Checking KWP device open");
             if (!m_kwpDevice.isOpen())
                 return KWPResult.DeviceNotConnected;
 
@@ -1235,7 +1235,7 @@ namespace TrionicCANLib.KWP
             result = RequestResult.Unknown; // <GS-11022010>
             while (_retryCount < _maxSendRetries && result != RequestResult.NoError)
             {
-                logger.Trace(a_request.ToString());
+                logger.Debug(a_request.ToString());
                 result = m_kwpDevice.sendRequest(a_request, out reply);
                 if ((int)reply.getLength() != expectedLength)
                 {
@@ -1246,15 +1246,15 @@ namespace TrionicCANLib.KWP
                 {
              
                     a_reply = reply;
-                    logger.Trace(reply.ToString());
-                    logger.Trace(""); // empty line
+                    logger.Debug(reply.ToString());
+                    logger.Debug(""); // empty line
                     m_requestMutex.ReleaseMutex();
                     //return KWPResult.OK;
                     _kwpResult = KWPResult.OK;
                 }
                 else
                 {
-                    logger.Trace("Error in KWPHandler::sendRequest" + result.ToString() + " " + reply.ToString());
+                    logger.Debug("Error in KWPHandler::sendRequest" + result.ToString() + " " + reply.ToString());
                     m_requestMutex.ReleaseMutex();
                     //return KWPResult.Timeout;
                     _kwpResult = KWPResult.Timeout;

--- a/TrionicCANLib/KWP/KWPHandler.cs
+++ b/TrionicCANLib/KWP/KWPHandler.cs
@@ -35,7 +35,7 @@ namespace TrionicCANLib.KWP
         private Mutex m_requestMutex = new Mutex();
         private TimerCallback timerDelegate;
         private System.Threading.Timer stateTimer;
-        private Logger logger = LogManager.GetCurrentClassLogger();
+        private static Logger logger = LogManager.GetCurrentClassLogger();
 
         /// <summary>
         /// Constructor.
@@ -43,14 +43,14 @@ namespace TrionicCANLib.KWP
         /// <param name="a_kwpDevice">IKWPDevice to be used by KWPHandler.</param>
         public static void setKWPDevice(IKWPDevice a_kwpDevice)
         {
-            Console.WriteLine("******* KWPHandler: KWP device set");
+            logger.Trace("******* KWPHandler: KWP device set");
             m_kwpDevice = a_kwpDevice;
         }
 
         public static KWPHandler getInstance()
         {
             if (m_kwpDevice == null)
-                Console.WriteLine("KWPDevice not set.");
+                logger.Trace("KWPDevice not set.");
             if (m_instance == null)
                 m_instance = new KWPHandler();
             return m_instance;
@@ -90,7 +90,7 @@ namespace TrionicCANLib.KWP
         {
             if (m_kwpDevice.isOpen() && !m_suspendAlivePolling)
             {
-                Console.WriteLine("Sending keep alive");
+                logger.Trace("Sending keep alive");
                 sendUnknownRequest();
             }
         }
@@ -111,7 +111,7 @@ namespace TrionicCANLib.KWP
         /// <returns>true on success, otherwise false.</returns>
         public bool openDevice()
         {
-            Console.WriteLine("******* KWPHandler: Opening kwpDevice");
+            logger.Trace("******* KWPHandler: Opening kwpDevice");
 
             return m_kwpDevice.open();
         }
@@ -122,7 +122,7 @@ namespace TrionicCANLib.KWP
         /// <returns>true on success, otherwise false.</returns>
         public bool closeDevice()
         {
-            Console.WriteLine("******* KWPHandler: Closing kwpDevice");
+            logger.Trace("******* KWPHandler: Closing kwpDevice");
 
             if(m_kwpDevice != null)
                 return m_kwpDevice.close();
@@ -161,16 +161,16 @@ namespace TrionicCANLib.KWP
             byte[] data = new byte[1];
             data[0] = (byte)0x00;
             KWPRequest req = new KWPRequest(0x11, 0x01, data);
-            Console.WriteLine(req.ToString());
+            logger.Trace(req.ToString());
             result = sendRequest(req, out reply);
             if (reply.getMode() == 0x51)
             {
-                Console.WriteLine("Reset Success: " + reply.ToString());
+                logger.Trace("Reset Success: " + reply.ToString());
                 return true;
             }
             else if (reply.getMode() == 0x7F)
             {
-                Console.WriteLine("Reset Failed: " + reply.ToString());
+                logger.Trace("Reset Failed: " + reply.ToString());
             }
             return false;
         }
@@ -185,9 +185,9 @@ namespace TrionicCANLib.KWP
             //data[1] = (byte)0x00;
             //data[2] = (byte)0x00;
             KWPRequest req = new KWPRequest(0x12, Convert.ToByte(frameNumber), data);
-            Console.WriteLine(req.ToString());
+            logger.Trace(req.ToString());
             result = sendRequest(req, out reply);
-            Console.WriteLine(reply.ToString());
+            logger.Trace(reply.ToString());
             return true;
         }
 
@@ -211,9 +211,9 @@ namespace TrionicCANLib.KWP
             // 1 Current code - present at time of request
             // 0 Maturing/intermittent code - insufficient data to consider as a malfunction
             KWPRequest req = new KWPRequest(0x18 , 0x02); // Request Diagnostic Trouble Codes by Status
-            Console.WriteLine(req.ToString());
+            logger.Trace(req.ToString());
             result = sendRequest(req, out reply);
-            Console.WriteLine(reply.ToString());
+            logger.Trace(reply.ToString());
             // J2190
             // Multiple Mode $58 response messages may be reported to a single request, depending on the number of diagnostic 
             // trouble codes stored in the module. Each response message will report up to three DTCs for
@@ -224,7 +224,7 @@ namespace TrionicCANLib.KWP
             {
                 if (reply.getPid() == 0x00)
                 {
-                    Console.WriteLine("No DTC's");
+                    logger.Trace("No DTC's");
                     list.Add("No DTC's");
                     return true;
                 }
@@ -278,9 +278,9 @@ namespace TrionicCANLib.KWP
             //data[1] = (byte)0xFF;
             //data[2] = (byte)0x00;
             KWPRequest req = new KWPRequest(0x14, (byte)(dtccode >> 8), data);
-            Console.WriteLine(req.ToString());
+            logger.Trace(req.ToString());
             result = sendRequest(req, out reply);
-            Console.WriteLine(reply.ToString());
+            logger.Trace(reply.ToString());
             return true;
         }
 
@@ -294,9 +294,9 @@ namespace TrionicCANLib.KWP
             //data[1] = (byte)0xFF;
             //data[2] = (byte)0x00;
             KWPRequest req = new KWPRequest(0x14, 0xFF, data);
-            Console.WriteLine(req.ToString());
+            logger.Trace(req.ToString());
             result = sendRequest(req, out reply);
-            Console.WriteLine(reply.ToString());
+            logger.Trace(reply.ToString());
             return true;
         }
 
@@ -315,9 +315,9 @@ namespace TrionicCANLib.KWP
             byte[] key = new byte[2];
             // Send a seed request.
             KWPRequest requestForKey = new KWPRequest(0x27, 0x05);
-            Console.WriteLine("requestSequrityAccessLevel " + a_method.ToString() +  " request for key: " + requestForKey.ToString());
+            logger.Trace("requestSequrityAccessLevel " + a_method.ToString() +  " request for key: " + requestForKey.ToString());
             result = sendRequest(requestForKey, out reply);
-            Console.WriteLine("requestSequrityAccessLevel " + a_method.ToString() + " request for key result: " + reply.ToString());
+            logger.Trace("requestSequrityAccessLevel " + a_method.ToString() + " request for key result: " + reply.ToString());
 
             if (result != KWPResult.OK)
                 return false;
@@ -331,25 +331,25 @@ namespace TrionicCANLib.KWP
                 key = calculateKey(seed, 1);
             // Send key reply.
             KWPRequest sendKeyRequest = new KWPRequest(0x27, 0x06, key);
-            Console.WriteLine("requestSequrityAccessLevel " + a_method.ToString() +  " send Key request: " + sendKeyRequest.ToString());
+            logger.Trace("requestSequrityAccessLevel " + a_method.ToString() +  " send Key request: " + sendKeyRequest.ToString());
             result = sendRequest(sendKeyRequest, out reply);
-            Console.WriteLine("requestSequrityAccessLevel " + a_method.ToString() + " send Key reply: " + reply.ToString());
+            logger.Trace("requestSequrityAccessLevel " + a_method.ToString() + " send Key reply: " + reply.ToString());
             if (result != KWPResult.OK)
             {
-                Console.WriteLine("Security access request was not send");
+                logger.Trace("Security access request was not send");
                 return false;
             }
 
             //Check if sequrity was granted.
-            Console.WriteLine("Mode: " + reply.getMode().ToString("X2"));
-            Console.WriteLine("Data: " + reply.getData()[0].ToString("X2"));
+            logger.Trace("Mode: " + reply.getMode().ToString("X2"));
+            logger.Trace("Data: " + reply.getData()[0].ToString("X2"));
             if ((reply.getMode() == 0x67) && (reply.getData()[0] == 0x34)) // WAS [0]
             {
-                Console.WriteLine("Security access granted: " + a_method.ToString());
+                logger.Trace("Security access granted: " + a_method.ToString());
                 return true;
             }
 
-            Console.WriteLine("Security access was not granted: " + reply.ToString());
+            logger.Trace("Security access was not granted: " + reply.ToString());
             return false;
         }
 
@@ -450,7 +450,7 @@ namespace TrionicCANLib.KWP
             }
             else if (reply.getMode() == 0x7F && reply.getPid() == 0x21 && reply.getLength() == 3)
             {
-                Console.WriteLine(TranslateErrorCode(reply.getData()[0]));
+                logger.Trace(TranslateErrorCode(reply.getData()[0]));
             }
             r_level = 0;
             return KWPResult.NOK;
@@ -476,7 +476,7 @@ namespace TrionicCANLib.KWP
             }
             else if(reply.getMode() == 0x7F && reply.getPid() == 0x3B && reply.getLength() == 3)
             {
-                Console.WriteLine(TranslateErrorCode(reply.getData()[0]));
+                logger.Trace(TranslateErrorCode(reply.getData()[0]));
             }
 
             return KWPResult.NOK;
@@ -629,18 +629,18 @@ namespace TrionicCANLib.KWP
             KWPRequest req = new KWPRequest(0x31, 0x50, a_data);
             
             result = sendRequest(req, out reply);
-            Console.WriteLine("Erase(1) " + reply.ToString());
+            logger.Trace("Erase(1) " + reply.ToString());
             /*if (result != KWPResult.OK)
                 return result;
             System.Threading.Thread.Sleep(10000);
             result = sendRequest(new KWPRequest(0x31, 0x53, a_data), out reply);
-            Console.WriteLine("Erase(2:" + i.ToString() + ") " + reply.ToString());
+            logger.Trace("Erase(2:" + i.ToString() + ") " + reply.ToString());
             */
             if (result != KWPResult.OK)
                 return result;
 
             result = sendRequest(new KWPRequest(0x3E, 0x50), out reply2); // tester present???
-            Console.WriteLine("reply on exit " + reply2.ToString());
+            logger.Trace("reply on exit " + reply2.ToString());
 
             return result;
         }
@@ -664,14 +664,14 @@ namespace TrionicCANLib.KWP
             //PID = 0x52
             //Expected result is 0x71
             result = sendRequest(new KWPRequest(0x31, 0x52), out reply);
-            Console.WriteLine("Erase(1) " + reply.ToString());
+            logger.Trace("Erase(1) " + reply.ToString());
             if (result != KWPResult.OK)
                 return result;
             while (reply.getMode() != 0x71) 
             {
                 System.Threading.Thread.Sleep(1000);
                 result = sendRequest(new KWPRequest(0x31, 0x52), out reply);
-                Console.WriteLine("Erase(2:" + i.ToString() + ") " + reply.ToString());
+                logger.Trace("Erase(2:" + i.ToString() + ") " + reply.ToString());
                 if (i++ > 15) return KWPResult.Timeout;
             }
             if (result != KWPResult.OK) 
@@ -683,14 +683,14 @@ namespace TrionicCANLib.KWP
             //Expected result is 0x71
             i = 0;
             result = sendRequest(new KWPRequest(0x31, 0x53), out reply2);
-            Console.WriteLine("Erase(3) " + reply2.ToString());
+            logger.Trace("Erase(3) " + reply2.ToString());
             if (result != KWPResult.OK)
                 return result;
             while (reply2.getMode() != 0x71)
             {
                 System.Threading.Thread.Sleep(1000);
                 result = sendRequest(new KWPRequest(0x31, 0x53), out reply2);
-                Console.WriteLine("Erase(4:" + i.ToString() + ") " + reply2.ToString());
+                logger.Trace("Erase(4:" + i.ToString() + ") " + reply2.ToString());
                 if (i++ > 20) return KWPResult.Timeout;
             }
 
@@ -698,7 +698,7 @@ namespace TrionicCANLib.KWP
             //Mode = 0x3E
             //Expected result is 0x7E
             result = sendRequest(new KWPRequest(0x3E, 0x53), out reply2);
-            Console.WriteLine("Erase(5) " + reply2.ToString());
+            logger.Trace("Erase(5) " + reply2.ToString());
 
             return result;
         }
@@ -798,7 +798,7 @@ namespace TrionicCANLib.KWP
         public KWPResult sendUnknownRequest()
         {
             logger.Trace("sendUnknownRequest");
-            //Console.WriteLine("sendUnknownRequest");
+            //logger.Trace("sendUnknownRequest");
             KWPReply reply = new KWPReply();
             KWPResult result;
 
@@ -836,6 +836,39 @@ namespace TrionicCANLib.KWP
                 return KWPResult.NOK;
             else
                 return result;
+        }
+
+        /// <summary>
+        /// This method send a request for reading from ECU memory (both RAM and flash). 
+        /// It sets up start address and the length to read. The resulting response contains the requested values.
+        /// </summary>
+        /// <param name="a_address">The address to start reading from.</param>
+        /// <param name="a_length">The total length to read.</param>
+        /// <returns>true on success, otherwise false</returns>
+        public bool sendReadRequest(uint a_address, uint a_length, out byte[] data) 
+        {
+            logger.Trace("sendReadRequest");
+
+            KWPReply reply = new KWPReply();
+            KWPResult result;
+            data = new byte[a_length];
+            byte[] lengthAndAddress = new byte[6];
+            //set address and length (byte 0)
+            lengthAndAddress[0] = (byte)(a_address >> 16);
+            lengthAndAddress[1] = (byte)(a_address >> 8);
+            lengthAndAddress[2] = (byte)(a_address);
+            lengthAndAddress[3] = (byte)(a_length);
+            lengthAndAddress[4] = 0x01;
+            lengthAndAddress[5] = 0;
+            KWPRequest request = new KWPRequest(0x23, lengthAndAddress);
+            request.ElmExpectedResponses = 1;
+            result = sendRequest(request, out reply);
+            data = reply.getData();
+            
+            if (result == KWPResult.OK)
+                return true;
+            else
+                return false;
         }
 
         /// <summary>
@@ -892,13 +925,11 @@ namespace TrionicCANLib.KWP
             int _retryCount = 0;
             while (_retryCount++ < 3 && result != KWPResult.OK)
             {
-                //result = sendRequest(new KWPRequest(0x2C, 0xF0, 0x03, symbolNumber), out reply);
-                result = sendRequest(new KWPRequest(0x2C, 0xF0, 0x03, symbolNumber), out reply/*, 2*/);
+                result = sendRequest(new KWPRequest(0x2C, 0xF0, 0x03, symbolNumber), out reply);
                 if (reply.getLength() != 2)
                 {
                     result = KWPResult.Timeout;
                     logger.Trace("Got wrong response on sendRequest in setSymbolRequest, len = " + reply.getLength().ToString("D2"));
-                    Console.WriteLine("Got wrong response on sendRequest in setSymbolRequest, len = " + reply.getLength().ToString("D2"));
                 }
             }
             if (result == KWPResult.OK)
@@ -908,7 +939,7 @@ namespace TrionicCANLib.KWP
             else
             {
                 logger.Trace("setSymbolRequest timed out");
-                Console.WriteLine("setSymbolRequest timed out");
+                logger.Trace("setSymbolRequest timed out");
                 return false;
             }
         }
@@ -943,19 +974,19 @@ namespace TrionicCANLib.KWP
             {
                 requestString += b.ToString("X2") + " ";
             }
-            Console.WriteLine(requestString);
+            logger.Trace(requestString);
             // end dump to console
-            Console.WriteLine("SymbolNumberAndData length: " + symbolNumberAndData.Length.ToString("X8"));
+            logger.Trace("SymbolNumberAndData length: " + symbolNumberAndData.Length.ToString("X8"));
             KWPRequest t_request = new KWPRequest(0x3D, /*0x81, */symbolNumberAndData);
-            Console.WriteLine(t_request.ToString());
+            logger.Trace(t_request.ToString());
             result = sendRequest(t_request, out reply);
             if (result != KWPResult.OK)
             {
-                Console.WriteLine("Result != KWPResult.OK");
+                logger.Trace("Result != KWPResult.OK");
                 return false;
             }
-            Console.WriteLine("Result = " + reply.getData()[0].ToString("X2"));
-            Console.WriteLine("Result-total = " + reply.ToString());
+            logger.Trace("Result = " + reply.getData()[0].ToString("X2"));
+            logger.Trace("Result-total = " + reply.ToString());
             if (reply.getData()[0] == 0x7D)
             {
                 return true;
@@ -997,19 +1028,19 @@ namespace TrionicCANLib.KWP
             {
                 requestString += b.ToString("X2") + " ";
             }
-            Console.WriteLine(requestString);
+            logger.Trace(requestString);
             // end dump to console
-            Console.WriteLine("SymbolNumberAndData length: " + symbolNumberAndData.Length.ToString("X8"));
+            logger.Trace("SymbolNumberAndData length: " + symbolNumberAndData.Length.ToString("X8"));
             KWPRequest t_request = new KWPRequest(0x3D, 0x80, symbolNumberAndData);
-            Console.WriteLine(t_request.ToString());
+            logger.Trace(t_request.ToString());
             result = sendRequest(t_request, out reply);
             if (result != KWPResult.OK)
             {
-                Console.WriteLine("Result != KWPResult.OK");
+                logger.Trace("Result != KWPResult.OK");
                 return false;
             }
-            Console.WriteLine("Result = " + reply.getData()[0].ToString("X2"));
-            Console.WriteLine("Resulttotal = " + reply.ToString());
+            logger.Trace("Result = " + reply.getData()[0].ToString("X2"));
+            logger.Trace("Resulttotal = " + reply.ToString());
             if (reply.getData()[0] == 0x7D)
             {
                 return true;
@@ -1051,18 +1082,18 @@ namespace TrionicCANLib.KWP
             {
                 requestString += b.ToString("X2") + " ";
             }
-            Console.WriteLine(requestString);
+            logger.Trace(requestString);
             // end dump to console
-            Console.WriteLine("SymbolNumberAndData length: " + symbolNumberAndData.Length.ToString("X8"));
+            logger.Trace("SymbolNumberAndData length: " + symbolNumberAndData.Length.ToString("X8"));
             KWPRequest t_request = new KWPRequest(0x3D, 0x80, symbolNumberAndData);
-            Console.WriteLine(t_request.ToString());
+            logger.Trace(t_request.ToString());
             result = sendRequest(t_request, out reply);
             if (result != KWPResult.OK)
             {
-                Console.WriteLine("Result != KWPResult.OK");
+                logger.Trace("Result != KWPResult.OK");
                 return false;
             }
-            Console.WriteLine("Result = " + reply.getData()[0].ToString("X2"));
+            logger.Trace("Result = " + reply.getData()[0].ToString("X2"));
             if (reply.getData()[0] == 0x7D)
             {
                 return true;
@@ -1139,7 +1170,7 @@ namespace TrionicCANLib.KWP
             KWPReply reply = new KWPReply();
             RequestResult result;
             a_reply = new KWPReply();
-            //Console.WriteLine("Checking KWP device open");
+            //logger.Trace("Checking KWP device open");
             if (!m_kwpDevice.isOpen())
                 return KWPResult.DeviceNotConnected;
 
@@ -1167,7 +1198,7 @@ namespace TrionicCANLib.KWP
                 else
                 {
                     logger.Trace("Error in KWPHandler::sendRequest: " + result.ToString() + " " + retry.ToString());
-                    Console.WriteLine("Error in KWPHandler::sendRequest: " + result.ToString() + " " + retry.ToString());
+                    logger.Trace("Error in KWPHandler::sendRequest: " + result.ToString() + " " + retry.ToString());
                 }
             }
             m_requestMutex.ReleaseMutex();
@@ -1185,11 +1216,11 @@ namespace TrionicCANLib.KWP
             int _maxSendRetries = 3;
             KWPResult _kwpResult = KWPResult.Timeout;
             logger.Trace("sendRequest");
-
+            
             KWPReply reply = new KWPReply();
             RequestResult result;
             a_reply = new KWPReply();
-            //Console.WriteLine("Checking KWP device open");
+            //logger.Trace("Checking KWP device open");
             if (!m_kwpDevice.isOpen())
                 return KWPResult.DeviceNotConnected;
 

--- a/TrionicCANLib/KWP/KWPReply.cs
+++ b/TrionicCANLib/KWP/KWPReply.cs
@@ -26,7 +26,7 @@ namespace TrionicCANLib.KWP
             m_reply = a_reply;
             if (m_reply == null)
             {
-                logger.Trace("Reply was NULL");
+                logger.Debug("Reply was NULL");
             }
             m_nrOfPid = a_nrOfPid;
         }

--- a/TrionicCANLib/KWP/KWPReply.cs
+++ b/TrionicCANLib/KWP/KWPReply.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using NLog;
 
 namespace TrionicCANLib.KWP
 {
@@ -9,6 +10,7 @@ namespace TrionicCANLib.KWP
     /// </summary>
     public class KWPReply
     {
+        private static Logger logger = LogManager.GetCurrentClassLogger();
         byte[] m_reply;
         uint m_nrOfPid;
 
@@ -24,7 +26,7 @@ namespace TrionicCANLib.KWP
             m_reply = a_reply;
             if (m_reply == null)
             {
-                Console.WriteLine("Reply was NULL");
+                logger.Trace("Reply was NULL");
             }
             m_nrOfPid = a_nrOfPid;
         }

--- a/TrionicCANLib/KWP/KWPRequest.cs
+++ b/TrionicCANLib/KWP/KWPRequest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using NLog;
 
 namespace TrionicCANLib.KWP
 {

--- a/TrionicCANLib/KWP/KWPRequest.cs
+++ b/TrionicCANLib/KWP/KWPRequest.cs
@@ -9,7 +9,7 @@ namespace TrionicCANLib.KWP
     /// </summary>
     public class KWPRequest
     {
-
+        private static Logger logger = LogManager.GetCurrentClassLogger();
         byte[] m_request;
         uint m_nrOfPid;
 
@@ -86,7 +86,7 @@ namespace TrionicCANLib.KWP
             byte length = (byte)(2 + a_data.Length);
             if(a_mode == 0x3D && a_pid == 0x80)
             {
-                Console.WriteLine("KWPRequest length: " + length.ToString("X8"));
+                logger.Trace("KWPRequest length: " + length.ToString("X8"));
             }
             m_request = new byte[length + 1];
             //Set length of request

--- a/TrionicCANLib/KWP/KWPRequest.cs
+++ b/TrionicCANLib/KWP/KWPRequest.cs
@@ -87,7 +87,7 @@ namespace TrionicCANLib.KWP
             byte length = (byte)(2 + a_data.Length);
             if(a_mode == 0x3D && a_pid == 0x80)
             {
-                logger.Trace("KWPRequest length: " + length.ToString("X8"));
+                logger.Debug("KWPRequest length: " + length.ToString("X8"));
             }
             m_request = new byte[length + 1];
             //Set length of request

--- a/TrionicCANLib/Trionic7.cs
+++ b/TrionicCANLib/Trionic7.cs
@@ -16,7 +16,7 @@ namespace TrionicCANLib.API
         private IKWPDevice kwpDevice;
         private KWPHandler kwpHandler;
         private IFlasher flash;
-        private Logger logger = LogManager.GetCurrentClassLogger();
+        private static Logger logger = LogManager.GetCurrentClassLogger();
 
         private bool m_UseFlasherOnDevice = false;
 
@@ -567,6 +567,32 @@ namespace TrionicCANLib.API
                 logger.Debug("Failed to read memory: " + E.Message);
             }
             return completedata;
+        }
+
+        public byte[] ReadValueFromSRAM(Int64 sramaddress, Int32 length, out bool _success)
+        {
+            _success = false;
+            byte[] data = new byte[length];
+            try
+            {
+                KWPHandler.getInstance().requestSequrityAccess(false);
+
+                if (canUsbDevice is LPCCANDevice) // or ELM327?
+                {
+                    Thread.Sleep(1);
+                }
+                if (KWPHandler.getInstance().sendReadRequest((uint)(sramaddress), (uint)length, out data))
+                {
+                    Thread.Sleep(0); //<GS-11022010>
+                     _success = true;
+                }
+            }
+            
+            catch (Exception E)
+            {
+                logger.Debug("Failed to read memory: " + E.Message);
+            }
+            return data;
         }
 
         public byte[] ReadMapFromSRAM(Int64 sramaddress, Int32 length, out bool _success)

--- a/TrionicCANLib/Trionic8.cs
+++ b/TrionicCANLib/Trionic8.cs
@@ -168,7 +168,7 @@ namespace TrionicCANLib.API
                     {
                         _securityAccessOk = true;
                         tmr.Start();
-                        logger.Trace("Timer started");
+                        logger.Debug("Timer started");
                         break;
                     }
                 }
@@ -199,7 +199,7 @@ namespace TrionicCANLib.API
             CANMessage response = new CANMessage();
             response = m_canListener.waitMessage(1000);
             //ulong data = response.getData();
-            logger.Trace("---" + response.getData().ToString("X16"));
+            logger.Debug("---" + response.getData().ToString("X16"));
             if (response.getCanData(1) == 0x67)
             {
                 if (response.getCanData(2) == 0x01)
@@ -291,7 +291,7 @@ namespace TrionicCANLib.API
             CANMessage response = new CANMessage();
             response = m_canListener.waitMessage(1000);
             //ulong data = response.getData();
-            logger.Trace("---" + response.getData().ToString("X16"));
+            logger.Debug("---" + response.getData().ToString("X16"));
             if (response.getCanData(1) == 0x67)
             {
                 if (response.getCanData(2) == 0xFD || response.getCanData(2) == 0xFB || response.getCanData(2) == 0x01)
@@ -352,7 +352,7 @@ namespace TrionicCANLib.API
                         }
                         response = new CANMessage();
                         response = m_canListener.waitMessage(1000);
-                        logger.Trace("---" + response.getData().ToString("X16"));
+                        logger.Debug("---" + response.getData().ToString("X16"));
                         // is it ok or not
                         if (response.getCanData(1) == 0x67 && (response.getCanData(2) == 0xFE || response.getCanData(2) == 0xFC || response.getCanData(2) == 0x02))
                         {
@@ -858,7 +858,7 @@ namespace TrionicCANLib.API
             msg.setData(data);
             if (!canUsbDevice.sendMessage(msg))
             {
-                logger.Trace("Failed to send message");
+                logger.Debug("Failed to send message");
             }
         }
 
@@ -943,7 +943,7 @@ namespace TrionicCANLib.API
             //9A = 01 10 0
             string retval = string.Empty;
             byte[] data = RequestECUInfo(0x9A);
-            logger.Trace("data: " + data[0].ToString("X2") + " " + data[1].ToString("X2"));
+            logger.Debug("data: " + data[0].ToString("X2") + " " + data[1].ToString("X2"));
             if (data[0] == 0x00 && data[1] == 0x00) return string.Empty;
             if (data.Length >= 2)
             {
@@ -1163,7 +1163,7 @@ namespace TrionicCANLib.API
             }
             CANMessage response62 = new CANMessage();
             response62 = m_canListener.waitMessage(1000);
-            logger.Trace("---" + response62.getData().ToString("X16"));
+            logger.Debug("---" + response62.getData().ToString("X16"));
             //05E8	62	00	00	02	A7	01	7F	01
             if (response62.getCanData(0) == 0x62)
             {
@@ -1191,7 +1191,7 @@ namespace TrionicCANLib.API
             }
             CANMessage response = new CANMessage();
             response = m_canListener.waitMessage(1000);
-            logger.Trace("---" + response.getData().ToString("X16"));
+            logger.Debug("---" + response.getData().ToString("X16"));
             //05E8	02	02	A0	42	80	A0	00	00
             if (response.getCanData(0) == 0x02)
             {
@@ -1226,7 +1226,7 @@ namespace TrionicCANLib.API
             highoutput = false;
             raw = string.Empty;
             byte[] data = RequestECUInfo(0x01);
-            logger.Trace("01data: " + data[0].ToString("X2") + " " + data[1].ToString("X2"));
+            logger.Debug("01data: " + data[0].ToString("X2") + " " + data[1].ToString("X2"));
 
             if (data[0] == 0x00 && data[1] == 0x00) return false;
             if (data.Length >= 2)
@@ -1308,7 +1308,7 @@ namespace TrionicCANLib.API
         {
             string retval = string.Empty;
             byte[] data = RequestECUInfo(0x03);
-            logger.Trace("03data: " + data[0].ToString("X2") + " " + data[1].ToString("X2"));
+            logger.Debug("03data: " + data[0].ToString("X2") + " " + data[1].ToString("X2"));
             if (data[0] == 0x00 && data[1] == 0x00) return string.Empty;
             if (data.Length >= 5)
             {
@@ -1325,7 +1325,7 @@ namespace TrionicCANLib.API
         {
             string retval = string.Empty;
             byte[] data = RequestECUInfo(0x04);
-            logger.Trace("04data: " + data[0].ToString("X2") + " " + data[1].ToString("X2"));
+            logger.Debug("04data: " + data[0].ToString("X2") + " " + data[1].ToString("X2"));
             if (data[0] == 0x00 && data[1] == 0x00) return string.Empty;
             if (data.Length >= 5)
             {
@@ -1342,7 +1342,7 @@ namespace TrionicCANLib.API
         {
             string retval = string.Empty;
             byte[] data = RequestECUInfo(0x07);
-            logger.Trace("07data: " + data[0].ToString("X2") + " " + data[1].ToString("X2"));
+            logger.Debug("07data: " + data[0].ToString("X2") + " " + data[1].ToString("X2"));
             if (data[0] == 0x00 && data[1] == 0x00) return string.Empty;
             if (data.Length >= 5)
             {
@@ -1359,7 +1359,7 @@ namespace TrionicCANLib.API
         {
             string retval = string.Empty;
             byte[] data = RequestECUInfo(0x2E);
-            logger.Trace("2Edata: " + data[0].ToString("X2") + " " + data[1].ToString("X2"));
+            logger.Debug("2Edata: " + data[0].ToString("X2") + " " + data[1].ToString("X2"));
             if (data.Length >= 5)
             {
                 for (int i = 0; i < data.Length; i++)
@@ -1375,7 +1375,7 @@ namespace TrionicCANLib.API
         {
             string retval = string.Empty;
             byte[] data = RequestECUInfo(0xB9);
-            logger.Trace("B9data: " + data[0].ToString("X2") + " " + data[1].ToString("X2"));
+            logger.Debug("B9data: " + data[0].ToString("X2") + " " + data[1].ToString("X2"));
             if (data[0] == 0x00 && data[1] == 0x00) return string.Empty;
             if (data.Length >= 5)
             {
@@ -1392,7 +1392,7 @@ namespace TrionicCANLib.API
         {
             string retval = string.Empty;
             byte[] data = RequestECUInfo(0x24);
-            logger.Trace("24data: " + data[0].ToString("X2") + " " + data[1].ToString("X2"));
+            logger.Debug("24data: " + data[0].ToString("X2") + " " + data[1].ToString("X2"));
             if (data[0] == 0x00 && data[1] == 0x00) return string.Empty;
             if (data.Length >= 5)
             {
@@ -1410,7 +1410,7 @@ namespace TrionicCANLib.API
         {
             string retval = string.Empty;
             byte[] data = RequestECUInfo(0xA0);
-            logger.Trace("A0data: " + data[0].ToString("X2") + " " + data[1].ToString("X2"));
+            logger.Debug("A0data: " + data[0].ToString("X2") + " " + data[1].ToString("X2"));
             if (data.Length >= 5)
             {
                 for (int i = 0; i < data.Length; i++)
@@ -1426,7 +1426,7 @@ namespace TrionicCANLib.API
         {
             string retval = string.Empty;
             byte[] data = RequestECUInfo(0x96);
-            logger.Trace("96data: " + data[0].ToString("X2") + " " + data[1].ToString("X2"));
+            logger.Debug("96data: " + data[0].ToString("X2") + " " + data[1].ToString("X2"));
             if (data.Length >= 11)
             {
                 for (int i = 0; i < data.Length; i++)
@@ -1732,7 +1732,7 @@ namespace TrionicCANLib.API
                 for (int i = 0; i < 0x46; i++)
                 {
                     //10 F0 36 00 00 10 24 00
-                    //logger.Trace("Sending bootloader: " + startAddress.ToString("X8"));
+                    //logger.Debug("Sending bootloader: " + startAddress.ToString("X8"));
                     // cast event
                     int percentage = (int)(((float)i * 100) / 70F);
                     if (percentage > saved_progress)
@@ -1783,7 +1783,7 @@ namespace TrionicCANLib.API
                     }
                     else
                     {
-                        logger.Trace("Did not receive correct response from SendTransferData");
+                        logger.Debug("Did not receive correct response from SendTransferData");
                     }
                 }
             }
@@ -1864,7 +1864,7 @@ namespace TrionicCANLib.API
 
         private int GetProgrammingState(uint responseID)
         {
-            logger.Trace("Get programming state");
+            logger.Debug("Get programming state");
             CANMessage msg = new CANMessage(0x11, 0, 2);
             ulong cmd = 0x000000000000A201; // 0x02 0x10 0x02
             msg.setData(cmd);
@@ -1877,7 +1877,7 @@ namespace TrionicCANLib.API
             response = new CANMessage();
             response = m_canListener.waitMessage(1000);
             ulong data = response.getData();
-            logger.Trace("Get programming state response: " + data.ToString("X16"));
+            logger.Debug("Get programming state response: " + data.ToString("X16"));
             //\__ 00 00 03 11 02 e2 01 00 00 00 00 00 Magic reply, T8 replies with 0311 and programming state 01(recovery state?)
             if (data == 0) return -1;
             if (getCanData(data, 1) != 0xE2 || getCanData(data, 0) != 0x02)
@@ -1966,7 +1966,7 @@ namespace TrionicCANLib.API
             CANMessage response = new CANMessage();
             response = m_canListener.waitMessage(1000);
             //ulong data = response.getData();
-            logger.Trace("---" + response.getData().ToString("X16"));
+            logger.Debug("---" + response.getData().ToString("X16"));
             if (response.getCanData(1) == 0x67)
             {
                 if (response.getCanData(2) == 0xFD || response.getCanData(2) == 0xFB || response.getCanData(2) == 0x01)
@@ -2323,7 +2323,7 @@ namespace TrionicCANLib.API
             ulong data = 0;
             // first send 
             CANMessage msg = new CANMessage(0x7E0, 0, 7);
-            //logger.Trace("Writing " + address.ToString("X8") + " len: " + memdata.Length.ToString("X2"));
+            //logger.Debug("Writing " + address.ToString("X8") + " len: " + memdata.Length.ToString("X2"));
             ulong cmd = 0x0000000000003406; // 0x34 = upload data to ECU
             ulong addressHigh = (uint)address & 0x0000000000FF0000;
             addressHigh /= 0x10000;
@@ -2365,7 +2365,7 @@ namespace TrionicCANLib.API
             cmd |= (addressMiddle * 0x1000000000000);
             cmd |= (addressHigh * 0x10000000000);
             cmd |= (len * 0x100);
-            //logger.Trace("send: " + cmd.ToString("X16"));
+            //logger.Debug("send: " + cmd.ToString("X16"));
 
             msg.setData(cmd);
             m_canListener.setupWaitMessage(0x7E8);
@@ -2408,7 +2408,7 @@ namespace TrionicCANLib.API
                 response = new CANMessage();
                 response = m_canListener.waitMessage(1000);
                 data = response.getData();
-                logger.Trace("received: " + data.ToString("X8"));
+                logger.Debug("received: " + data.ToString("X8"));
             }
             _stallKeepAlive = false;
             return true;
@@ -2420,7 +2420,7 @@ namespace TrionicCANLib.API
             ulong cmd = 0x0000000000003E01; // always 2 bytes
             msg.setData(cmd);
             msg.elmExpectedResponses = 1;
-            //logger.Trace("KA sent");
+            //logger.Debug("KA sent");
             m_canListener.setupWaitMessage(0x7E8);
             if (!canUsbDevice.sendMessage(msg))
             {
@@ -2429,7 +2429,7 @@ namespace TrionicCANLib.API
             CANMessage response = new CANMessage();
             response = new CANMessage();
             response = m_canListener.waitMessage(1000);
-            //logger.Trace("received KA: " + response.getCanData(1).ToString("X2"));
+            //logger.Debug("received KA: " + response.getCanData(1).ToString("X2"));
         }
 
         public byte[] getSRAMSnapshot()
@@ -2505,7 +2505,7 @@ namespace TrionicCANLib.API
             if (!canUsbDevice.isOpen()) return retData;
 
             CANMessage msg = new CANMessage(0x7E0, 0, 7);
-            //logger.Trace("Reading " + address.ToString("X8") + " len: " + length.ToString("X2"));
+            //logger.Debug("Reading " + address.ToString("X8") + " len: " + length.ToString("X2"));
             ulong cmd = 0x0000000000002106; // always 2 bytes
             ulong addressHigh = (uint)address & 0x0000000000FF0000;
             addressHigh /= 0x10000;
@@ -2519,7 +2519,7 @@ namespace TrionicCANLib.API
             cmd |= (addressMiddle * 0x10000000000);
             cmd |= (addressHigh * 0x100000000);
             cmd |= (len * 0x10000); // << 2 * 8
-            //logger.Trace("send: " + cmd.ToString("X16"));
+            //logger.Debug("send: " + cmd.ToString("X16"));
             /*cmd |= (ulong)(byte)(address & 0x000000FF) << 4 * 8;
             cmd |= (ulong)(byte)((address & 0x0000FF00) >> 8) << 3 * 8;
             cmd |= (ulong)(byte)((address & 0x00FF0000) >> 2 * 8) << 2 * 8;
@@ -2660,7 +2660,7 @@ namespace TrionicCANLib.API
             //optimize reading speed for ELM
             if (length <= 3)
                 msg.elmExpectedResponses = 1;
-            //logger.Trace("Reading " + address.ToString("X8") + " len: " + length.ToString("X2"));
+            //logger.Debug("Reading " + address.ToString("X8") + " len: " + length.ToString("X2"));
             ulong cmd = 0x0000000000002306; // always 2 bytes
             ulong addressHigh = (uint)address & 0x0000000000FF0000;
             addressHigh /= 0x10000;
@@ -2674,7 +2674,7 @@ namespace TrionicCANLib.API
             cmd |= (addressMiddle * 0x1000000);
             cmd |= (addressHigh * 0x10000);
             cmd |= (len * 0x1000000000000);
-            //logger.Trace("send: " + cmd.ToString("X16"));
+            //logger.Debug("send: " + cmd.ToString("X16"));
             /*cmd |= (ulong)(byte)(address & 0x000000FF) << 4 * 8;
             cmd |= (ulong)(byte)((address & 0x0000FF00) >> 8) << 3 * 8;
             cmd |= (ulong)(byte)((address & 0x00FF0000) >> 2 * 8) << 2 * 8;
@@ -3212,7 +3212,7 @@ namespace TrionicCANLib.API
 
         private int GetProgrammingStateNormal()
         {
-            logger.Trace("Get programming state");
+            logger.Debug("Get programming state");
             CANMessage msg = new CANMessage(0x7E0, 0, 2);
             ulong cmd = 0x000000000000A201; // 0x02 0x10 0x02
             msg.setData(cmd);
@@ -3225,7 +3225,7 @@ namespace TrionicCANLib.API
             response = new CANMessage();
             response = m_canListener.waitMessage(1000);
             ulong data = response.getData();
-            logger.Trace("Get programming state response: " + data.ToString("X16"));
+            logger.Debug("Get programming state response: " + data.ToString("X16"));
             //\__ 00 00 03 11 02 e2 01 00 00 00 00 00 Magic reply, T8 replies with 0311 and programming state 01(recovery state?)
             if (getCanData(data, 1) != 0xE2 || getCanData(data, 0) != 0x02)
             {
@@ -3885,7 +3885,7 @@ namespace TrionicCANLib.API
                 {
                     iFrameNumber = 0x21;
                     //10 F0 36 00 00 10 24 00
-                    //logger.Trace("Sending bootloader: " + startAddress.ToString("X8"));
+                    //logger.Debug("Sending bootloader: " + startAddress.ToString("X8"));
                     // cast event
                     int percentage = (int)(((float)i * 100) / 70F);
                     if (percentage > saved_progress)
@@ -3932,7 +3932,7 @@ namespace TrionicCANLib.API
                     }
                     else
                     {
-                        logger.Trace("Did not receive correct response from SendTransferData");
+                        logger.Debug("Did not receive correct response from SendTransferData");
                     }
                 }
 
@@ -3964,7 +3964,7 @@ namespace TrionicCANLib.API
                 }
                 else
                 {
-                    logger.Trace("Did not receive correct response from SendTransferData");
+                    logger.Debug("Did not receive correct response from SendTransferData");
                 }
 
                 CastProgressWriteEvent(100);
@@ -3985,7 +3985,7 @@ namespace TrionicCANLib.API
                 {
                     iFrameNumber = 0x21;
                     //10 F0 36 00 00 10 24 00
-                    //logger.Trace("Sending bootloader: " + startAddress.ToString("X8"));
+                    //logger.Debug("Sending bootloader: " + startAddress.ToString("X8"));
                     // cast event
                     int percentage = (int)(((float)i * 100) / 70F);
                     if (percentage > saved_progress)
@@ -4030,7 +4030,7 @@ namespace TrionicCANLib.API
                     }
                     else
                     {
-                        logger.Trace("Did not receive correct response from SendTransferData");
+                        logger.Debug("Did not receive correct response from SendTransferData");
                     }
                 }
 
@@ -4061,14 +4061,14 @@ namespace TrionicCANLib.API
                 }
                 else
                 {
-                    logger.Trace("Did not receive correct response from SendTransferData");
+                    logger.Debug("Did not receive correct response from SendTransferData");
                 }
 
                 CastProgressWriteEvent(100);
             }
             else
             {
-                logger.Trace("requestDownload() failed");
+                logger.Debug("requestDownload() failed");
                 return false;
             }
             return true;
@@ -4087,7 +4087,7 @@ namespace TrionicCANLib.API
                 {
                     iFrameNumber = 0x21;
                     //10 F0 36 00 00 10 24 00
-                    //logger.Trace("Sending bootloader: " + startAddress.ToString("X8"));
+                    //logger.Debug("Sending bootloader: " + startAddress.ToString("X8"));
                     // cast event
                     int percentage = (int)(((float)i * 100) / 70F);
                     if (percentage > saved_progress)
@@ -4130,7 +4130,7 @@ namespace TrionicCANLib.API
                     }
                     else
                     {
-                        logger.Trace("Did not receive correct response from SendTransferData");
+                        logger.Debug("Did not receive correct response from SendTransferData");
                     }
                 }
 
@@ -4163,7 +4163,7 @@ namespace TrionicCANLib.API
                 }
                 else
                 {
-                    logger.Trace("Did not receive correct response from SendTransferData");
+                    logger.Debug("Did not receive correct response from SendTransferData");
                 }
 
                 CastProgressWriteEvent(100);
@@ -4176,7 +4176,7 @@ namespace TrionicCANLib.API
             BackgroundWorker bw = sender as BackgroundWorker;
             string filename = (string)workEvent.Argument;
             string diagDataID = GetDiagnosticDataIdentifier0101();
-            logger.Trace("DataID: " + diagDataID);
+            logger.Debug("DataID: " + diagDataID);
             if (diagDataID == string.Empty)
             {
                 canUsbDevice.SetupCANFilter("7E8", "000");
@@ -4847,7 +4847,7 @@ namespace TrionicCANLib.API
                 }
                 else
                 {
-                    logger.Trace("Rx: " + data.ToString("X16"));
+                    logger.Debug("Rx: " + data.ToString("X16"));
                     if (canUsbDevice is CANELM327Device)
                     {
                         if (recoveryMode) BroadcastKeepAlive();
@@ -4891,7 +4891,7 @@ namespace TrionicCANLib.API
             cmd |= (addressMiddle * 0x1000000000000);
             cmd |= (addressHigh * 0x10000000000);
             cmd |= (len * 0x100);
-            //logger.Trace("send: " + cmd.ToString("X16"));
+            //logger.Debug("send: " + cmd.ToString("X16"));
             msg.elmExpectedResponses = 1;
             msg.setData(cmd);
             m_canListener.setupWaitMessage(waitforResponseID);
@@ -4904,7 +4904,7 @@ namespace TrionicCANLib.API
             response = new CANMessage();
             response = m_canListener.waitMessage(1000);
             ulong data = response.getData();
-            //logger.Trace("Received in SendTransferData: " + data.ToString("X16"));
+            //logger.Debug("Received in SendTransferData: " + data.ToString("X16"));
             if (getCanData(data, 0) != 0x30 || getCanData(data, 1) != 0x00)
             {
                 return false;
@@ -4927,7 +4927,7 @@ namespace TrionicCANLib.API
             cmd |= (addressMiddle * 0x1000000000000);
             cmd |= (addressHigh * 0x10000000000);
             cmd |= (len * 0x100);
-            //logger.Trace("send: " + cmd.ToString("X16"));
+            //logger.Debug("send: " + cmd.ToString("X16"));
 
             msg.setData(cmd);
             msg.elmExpectedResponses = 1;
@@ -4941,7 +4941,7 @@ namespace TrionicCANLib.API
             response = new CANMessage();
             response = m_canListener.waitMessage(1000);
             ulong data = response.getData();
-            //logger.Trace("Received in SendTransferData: " + data.ToString("X16"));
+            //logger.Debug("Received in SendTransferData: " + data.ToString("X16"));
             if (getCanData(data, 0) != 0x30 || getCanData(data, 1) != 0x00)
             {
                 return false;
@@ -5077,7 +5077,7 @@ namespace TrionicCANLib.API
             //optimize reading speed for ELM
             if (length <= 3)
                 msg.elmExpectedResponses = 1;
-            //logger.Trace("Reading " + address.ToString("X8") + " len: " + length.ToString("X2"));
+            //logger.Debug("Reading " + address.ToString("X8") + " len: " + length.ToString("X2"));
             ulong cmd = 0x0000000000002307; // always 2 bytes
             ulong addressHigh = (uint)address & 0x0000000000FF0000;
             addressHigh /= 0x10000;
@@ -5091,7 +5091,7 @@ namespace TrionicCANLib.API
             cmd |= (addressMiddle * 0x100000000);
             cmd |= (addressHigh * 0x1000000);
             cmd |= (len * 0x100000000000000);
-            //logger.Trace("send: " + cmd.ToString("X16"));
+            //logger.Debug("send: " + cmd.ToString("X16"));
             /*cmd |= (ulong)(byte)(address & 0x000000FF) << 4 * 8;
             cmd |= (ulong)(byte)((address & 0x0000FF00) >> 8) << 3 * 8;
             cmd |= (ulong)(byte)((address & 0x00FF0000) >> 2 * 8) << 2 * 8;
@@ -5366,7 +5366,7 @@ namespace TrionicCANLib.API
                 }
                 else
                 {
-                    logger.Trace("Rx: " + data.ToString("X16"));
+                    logger.Debug("Rx: " + data.ToString("X16"));
                     if (canUsbDevice is CANELM327Device)
                     {
                         if (recoveryMode) BroadcastKeepAlive();
@@ -5490,7 +5490,7 @@ namespace TrionicCANLib.API
             cmd |= (addressMiddle * 0x1000000000000);
             cmd |= (addressHigh * 0x10000000000);
             cmd |= (len * 0x100);
-            logger.Trace("send: " + cmd.ToString("X16"));
+            logger.Debug("send: " + cmd.ToString("X16"));
 
             msg.setData(cmd);
             msg.elmExpectedResponses = 1;
@@ -5504,7 +5504,7 @@ namespace TrionicCANLib.API
             response = new CANMessage();
             response = m_canListener.waitMessage(1000);
             ulong data = response.getData();
-            logger.Trace("Received in SendTransferData: " + data.ToString("X16"));
+            logger.Debug("Received in SendTransferData: " + data.ToString("X16"));
             if (getCanData(data, 0) != 0x30 || getCanData(data, 1) != 0x00)
             {
                 return false;

--- a/TrionicCANLib/Trionic8.cs
+++ b/TrionicCANLib/Trionic8.cs
@@ -18,7 +18,7 @@ namespace TrionicCANLib.API
     public class Trionic8 : ITrionic
     {
         AccessLevel _securityLevel = AccessLevel.AccessLevelFD; // by default 0xFD
-        private Logger logger = LogManager.GetCurrentClassLogger();
+        private static Logger logger = LogManager.GetCurrentClassLogger();
 
         private ECU m_ECU = ECU.TRIONIC8;
 
@@ -168,7 +168,7 @@ namespace TrionicCANLib.API
                     {
                         _securityAccessOk = true;
                         tmr.Start();
-                        Console.WriteLine("Timer started");
+                        logger.Trace("Timer started");
                         break;
                     }
                 }
@@ -199,7 +199,7 @@ namespace TrionicCANLib.API
             CANMessage response = new CANMessage();
             response = m_canListener.waitMessage(1000);
             //ulong data = response.getData();
-            Console.WriteLine("---" + response.getData().ToString("X16"));
+            logger.Trace("---" + response.getData().ToString("X16"));
             if (response.getCanData(1) == 0x67)
             {
                 if (response.getCanData(2) == 0x01)
@@ -291,7 +291,7 @@ namespace TrionicCANLib.API
             CANMessage response = new CANMessage();
             response = m_canListener.waitMessage(1000);
             //ulong data = response.getData();
-            Console.WriteLine("---" + response.getData().ToString("X16"));
+            logger.Trace("---" + response.getData().ToString("X16"));
             if (response.getCanData(1) == 0x67)
             {
                 if (response.getCanData(2) == 0xFD || response.getCanData(2) == 0xFB || response.getCanData(2) == 0x01)
@@ -352,7 +352,7 @@ namespace TrionicCANLib.API
                         }
                         response = new CANMessage();
                         response = m_canListener.waitMessage(1000);
-                        Console.WriteLine("---" + response.getData().ToString("X16"));
+                        logger.Trace("---" + response.getData().ToString("X16"));
                         // is it ok or not
                         if (response.getCanData(1) == 0x67 && (response.getCanData(2) == 0xFE || response.getCanData(2) == 0xFC || response.getCanData(2) == 0x02))
                         {
@@ -858,7 +858,7 @@ namespace TrionicCANLib.API
             msg.setData(data);
             if (!canUsbDevice.sendMessage(msg))
             {
-                Console.WriteLine("Failed to send message");
+                logger.Trace("Failed to send message");
             }
         }
 
@@ -943,7 +943,7 @@ namespace TrionicCANLib.API
             //9A = 01 10 0
             string retval = string.Empty;
             byte[] data = RequestECUInfo(0x9A);
-            Console.WriteLine("data: " + data[0].ToString("X2") + " " + data[1].ToString("X2"));
+            logger.Trace("data: " + data[0].ToString("X2") + " " + data[1].ToString("X2"));
             if (data[0] == 0x00 && data[1] == 0x00) return string.Empty;
             if (data.Length >= 2)
             {
@@ -1163,7 +1163,7 @@ namespace TrionicCANLib.API
             }
             CANMessage response62 = new CANMessage();
             response62 = m_canListener.waitMessage(1000);
-            Console.WriteLine("---" + response62.getData().ToString("X16"));
+            logger.Trace("---" + response62.getData().ToString("X16"));
             //05E8	62	00	00	02	A7	01	7F	01
             if (response62.getCanData(0) == 0x62)
             {
@@ -1191,7 +1191,7 @@ namespace TrionicCANLib.API
             }
             CANMessage response = new CANMessage();
             response = m_canListener.waitMessage(1000);
-            Console.WriteLine("---" + response.getData().ToString("X16"));
+            logger.Trace("---" + response.getData().ToString("X16"));
             //05E8	02	02	A0	42	80	A0	00	00
             if (response.getCanData(0) == 0x02)
             {
@@ -1226,7 +1226,7 @@ namespace TrionicCANLib.API
             highoutput = false;
             raw = string.Empty;
             byte[] data = RequestECUInfo(0x01);
-            Console.WriteLine("01data: " + data[0].ToString("X2") + " " + data[1].ToString("X2"));
+            logger.Trace("01data: " + data[0].ToString("X2") + " " + data[1].ToString("X2"));
 
             if (data[0] == 0x00 && data[1] == 0x00) return false;
             if (data.Length >= 2)
@@ -1308,7 +1308,7 @@ namespace TrionicCANLib.API
         {
             string retval = string.Empty;
             byte[] data = RequestECUInfo(0x03);
-            Console.WriteLine("03data: " + data[0].ToString("X2") + " " + data[1].ToString("X2"));
+            logger.Trace("03data: " + data[0].ToString("X2") + " " + data[1].ToString("X2"));
             if (data[0] == 0x00 && data[1] == 0x00) return string.Empty;
             if (data.Length >= 5)
             {
@@ -1325,7 +1325,7 @@ namespace TrionicCANLib.API
         {
             string retval = string.Empty;
             byte[] data = RequestECUInfo(0x04);
-            Console.WriteLine("04data: " + data[0].ToString("X2") + " " + data[1].ToString("X2"));
+            logger.Trace("04data: " + data[0].ToString("X2") + " " + data[1].ToString("X2"));
             if (data[0] == 0x00 && data[1] == 0x00) return string.Empty;
             if (data.Length >= 5)
             {
@@ -1342,7 +1342,7 @@ namespace TrionicCANLib.API
         {
             string retval = string.Empty;
             byte[] data = RequestECUInfo(0x07);
-            Console.WriteLine("07data: " + data[0].ToString("X2") + " " + data[1].ToString("X2"));
+            logger.Trace("07data: " + data[0].ToString("X2") + " " + data[1].ToString("X2"));
             if (data[0] == 0x00 && data[1] == 0x00) return string.Empty;
             if (data.Length >= 5)
             {
@@ -1359,7 +1359,7 @@ namespace TrionicCANLib.API
         {
             string retval = string.Empty;
             byte[] data = RequestECUInfo(0x2E);
-            Console.WriteLine("2Edata: " + data[0].ToString("X2") + " " + data[1].ToString("X2"));
+            logger.Trace("2Edata: " + data[0].ToString("X2") + " " + data[1].ToString("X2"));
             if (data.Length >= 5)
             {
                 for (int i = 0; i < data.Length; i++)
@@ -1375,7 +1375,7 @@ namespace TrionicCANLib.API
         {
             string retval = string.Empty;
             byte[] data = RequestECUInfo(0xB9);
-            Console.WriteLine("B9data: " + data[0].ToString("X2") + " " + data[1].ToString("X2"));
+            logger.Trace("B9data: " + data[0].ToString("X2") + " " + data[1].ToString("X2"));
             if (data[0] == 0x00 && data[1] == 0x00) return string.Empty;
             if (data.Length >= 5)
             {
@@ -1392,7 +1392,7 @@ namespace TrionicCANLib.API
         {
             string retval = string.Empty;
             byte[] data = RequestECUInfo(0x24);
-            Console.WriteLine("24data: " + data[0].ToString("X2") + " " + data[1].ToString("X2"));
+            logger.Trace("24data: " + data[0].ToString("X2") + " " + data[1].ToString("X2"));
             if (data[0] == 0x00 && data[1] == 0x00) return string.Empty;
             if (data.Length >= 5)
             {
@@ -1410,7 +1410,7 @@ namespace TrionicCANLib.API
         {
             string retval = string.Empty;
             byte[] data = RequestECUInfo(0xA0);
-            Console.WriteLine("A0data: " + data[0].ToString("X2") + " " + data[1].ToString("X2"));
+            logger.Trace("A0data: " + data[0].ToString("X2") + " " + data[1].ToString("X2"));
             if (data.Length >= 5)
             {
                 for (int i = 0; i < data.Length; i++)
@@ -1426,7 +1426,7 @@ namespace TrionicCANLib.API
         {
             string retval = string.Empty;
             byte[] data = RequestECUInfo(0x96);
-            Console.WriteLine("96data: " + data[0].ToString("X2") + " " + data[1].ToString("X2"));
+            logger.Trace("96data: " + data[0].ToString("X2") + " " + data[1].ToString("X2"));
             if (data.Length >= 11)
             {
                 for (int i = 0; i < data.Length; i++)
@@ -1732,7 +1732,7 @@ namespace TrionicCANLib.API
                 for (int i = 0; i < 0x46; i++)
                 {
                     //10 F0 36 00 00 10 24 00
-                    //Console.WriteLine("Sending bootloader: " + startAddress.ToString("X8"));
+                    //logger.Trace("Sending bootloader: " + startAddress.ToString("X8"));
                     // cast event
                     int percentage = (int)(((float)i * 100) / 70F);
                     if (percentage > saved_progress)
@@ -1783,7 +1783,7 @@ namespace TrionicCANLib.API
                     }
                     else
                     {
-                        Console.WriteLine("Did not receive correct response from SendTransferData");
+                        logger.Trace("Did not receive correct response from SendTransferData");
                     }
                 }
             }
@@ -1864,7 +1864,7 @@ namespace TrionicCANLib.API
 
         private int GetProgrammingState(uint responseID)
         {
-            Console.WriteLine("Get programming state");
+            logger.Trace("Get programming state");
             CANMessage msg = new CANMessage(0x11, 0, 2);
             ulong cmd = 0x000000000000A201; // 0x02 0x10 0x02
             msg.setData(cmd);
@@ -1877,7 +1877,7 @@ namespace TrionicCANLib.API
             response = new CANMessage();
             response = m_canListener.waitMessage(1000);
             ulong data = response.getData();
-            Console.WriteLine("Get programming state response: " + data.ToString("X16"));
+            logger.Trace("Get programming state response: " + data.ToString("X16"));
             //\__ 00 00 03 11 02 e2 01 00 00 00 00 00 Magic reply, T8 replies with 0311 and programming state 01(recovery state?)
             if (data == 0) return -1;
             if (getCanData(data, 1) != 0xE2 || getCanData(data, 0) != 0x02)
@@ -1966,7 +1966,7 @@ namespace TrionicCANLib.API
             CANMessage response = new CANMessage();
             response = m_canListener.waitMessage(1000);
             //ulong data = response.getData();
-            Console.WriteLine("---" + response.getData().ToString("X16"));
+            logger.Trace("---" + response.getData().ToString("X16"));
             if (response.getCanData(1) == 0x67)
             {
                 if (response.getCanData(2) == 0xFD || response.getCanData(2) == 0xFB || response.getCanData(2) == 0x01)
@@ -2323,7 +2323,7 @@ namespace TrionicCANLib.API
             ulong data = 0;
             // first send 
             CANMessage msg = new CANMessage(0x7E0, 0, 7);
-            //Console.WriteLine("Writing " + address.ToString("X8") + " len: " + memdata.Length.ToString("X2"));
+            //logger.Trace("Writing " + address.ToString("X8") + " len: " + memdata.Length.ToString("X2"));
             ulong cmd = 0x0000000000003406; // 0x34 = upload data to ECU
             ulong addressHigh = (uint)address & 0x0000000000FF0000;
             addressHigh /= 0x10000;
@@ -2365,7 +2365,7 @@ namespace TrionicCANLib.API
             cmd |= (addressMiddle * 0x1000000000000);
             cmd |= (addressHigh * 0x10000000000);
             cmd |= (len * 0x100);
-            //Console.WriteLine("send: " + cmd.ToString("X16"));
+            //logger.Trace("send: " + cmd.ToString("X16"));
 
             msg.setData(cmd);
             m_canListener.setupWaitMessage(0x7E8);
@@ -2408,7 +2408,7 @@ namespace TrionicCANLib.API
                 response = new CANMessage();
                 response = m_canListener.waitMessage(1000);
                 data = response.getData();
-                Console.WriteLine("received: " + data.ToString("X8"));
+                logger.Trace("received: " + data.ToString("X8"));
             }
             _stallKeepAlive = false;
             return true;
@@ -2420,7 +2420,7 @@ namespace TrionicCANLib.API
             ulong cmd = 0x0000000000003E01; // always 2 bytes
             msg.setData(cmd);
             msg.elmExpectedResponses = 1;
-            //Console.WriteLine("KA sent");
+            //logger.Trace("KA sent");
             m_canListener.setupWaitMessage(0x7E8);
             if (!canUsbDevice.sendMessage(msg))
             {
@@ -2429,7 +2429,7 @@ namespace TrionicCANLib.API
             CANMessage response = new CANMessage();
             response = new CANMessage();
             response = m_canListener.waitMessage(1000);
-            //Console.WriteLine("received KA: " + response.getCanData(1).ToString("X2"));
+            //logger.Trace("received KA: " + response.getCanData(1).ToString("X2"));
         }
 
         public byte[] getSRAMSnapshot()
@@ -2505,7 +2505,7 @@ namespace TrionicCANLib.API
             if (!canUsbDevice.isOpen()) return retData;
 
             CANMessage msg = new CANMessage(0x7E0, 0, 7);
-            //Console.WriteLine("Reading " + address.ToString("X8") + " len: " + length.ToString("X2"));
+            //logger.Trace("Reading " + address.ToString("X8") + " len: " + length.ToString("X2"));
             ulong cmd = 0x0000000000002106; // always 2 bytes
             ulong addressHigh = (uint)address & 0x0000000000FF0000;
             addressHigh /= 0x10000;
@@ -2519,7 +2519,7 @@ namespace TrionicCANLib.API
             cmd |= (addressMiddle * 0x10000000000);
             cmd |= (addressHigh * 0x100000000);
             cmd |= (len * 0x10000); // << 2 * 8
-            //Console.WriteLine("send: " + cmd.ToString("X16"));
+            //logger.Trace("send: " + cmd.ToString("X16"));
             /*cmd |= (ulong)(byte)(address & 0x000000FF) << 4 * 8;
             cmd |= (ulong)(byte)((address & 0x0000FF00) >> 8) << 3 * 8;
             cmd |= (ulong)(byte)((address & 0x00FF0000) >> 2 * 8) << 2 * 8;
@@ -2660,7 +2660,7 @@ namespace TrionicCANLib.API
             //optimize reading speed for ELM
             if (length <= 3)
                 msg.elmExpectedResponses = 1;
-            //Console.WriteLine("Reading " + address.ToString("X8") + " len: " + length.ToString("X2"));
+            //logger.Trace("Reading " + address.ToString("X8") + " len: " + length.ToString("X2"));
             ulong cmd = 0x0000000000002306; // always 2 bytes
             ulong addressHigh = (uint)address & 0x0000000000FF0000;
             addressHigh /= 0x10000;
@@ -2674,7 +2674,7 @@ namespace TrionicCANLib.API
             cmd |= (addressMiddle * 0x1000000);
             cmd |= (addressHigh * 0x10000);
             cmd |= (len * 0x1000000000000);
-            //Console.WriteLine("send: " + cmd.ToString("X16"));
+            //logger.Trace("send: " + cmd.ToString("X16"));
             /*cmd |= (ulong)(byte)(address & 0x000000FF) << 4 * 8;
             cmd |= (ulong)(byte)((address & 0x0000FF00) >> 8) << 3 * 8;
             cmd |= (ulong)(byte)((address & 0x00FF0000) >> 2 * 8) << 2 * 8;
@@ -3212,7 +3212,7 @@ namespace TrionicCANLib.API
 
         private int GetProgrammingStateNormal()
         {
-            Console.WriteLine("Get programming state");
+            logger.Trace("Get programming state");
             CANMessage msg = new CANMessage(0x7E0, 0, 2);
             ulong cmd = 0x000000000000A201; // 0x02 0x10 0x02
             msg.setData(cmd);
@@ -3225,7 +3225,7 @@ namespace TrionicCANLib.API
             response = new CANMessage();
             response = m_canListener.waitMessage(1000);
             ulong data = response.getData();
-            Console.WriteLine("Get programming state response: " + data.ToString("X16"));
+            logger.Trace("Get programming state response: " + data.ToString("X16"));
             //\__ 00 00 03 11 02 e2 01 00 00 00 00 00 Magic reply, T8 replies with 0311 and programming state 01(recovery state?)
             if (getCanData(data, 1) != 0xE2 || getCanData(data, 0) != 0x02)
             {
@@ -3885,7 +3885,7 @@ namespace TrionicCANLib.API
                 {
                     iFrameNumber = 0x21;
                     //10 F0 36 00 00 10 24 00
-                    //Console.WriteLine("Sending bootloader: " + startAddress.ToString("X8"));
+                    //logger.Trace("Sending bootloader: " + startAddress.ToString("X8"));
                     // cast event
                     int percentage = (int)(((float)i * 100) / 70F);
                     if (percentage > saved_progress)
@@ -3932,7 +3932,7 @@ namespace TrionicCANLib.API
                     }
                     else
                     {
-                        Console.WriteLine("Did not receive correct response from SendTransferData");
+                        logger.Trace("Did not receive correct response from SendTransferData");
                     }
                 }
 
@@ -3964,7 +3964,7 @@ namespace TrionicCANLib.API
                 }
                 else
                 {
-                    Console.WriteLine("Did not receive correct response from SendTransferData");
+                    logger.Trace("Did not receive correct response from SendTransferData");
                 }
 
                 CastProgressWriteEvent(100);
@@ -3985,7 +3985,7 @@ namespace TrionicCANLib.API
                 {
                     iFrameNumber = 0x21;
                     //10 F0 36 00 00 10 24 00
-                    //Console.WriteLine("Sending bootloader: " + startAddress.ToString("X8"));
+                    //logger.Trace("Sending bootloader: " + startAddress.ToString("X8"));
                     // cast event
                     int percentage = (int)(((float)i * 100) / 70F);
                     if (percentage > saved_progress)
@@ -4030,7 +4030,7 @@ namespace TrionicCANLib.API
                     }
                     else
                     {
-                        Console.WriteLine("Did not receive correct response from SendTransferData");
+                        logger.Trace("Did not receive correct response from SendTransferData");
                     }
                 }
 
@@ -4061,14 +4061,14 @@ namespace TrionicCANLib.API
                 }
                 else
                 {
-                    Console.WriteLine("Did not receive correct response from SendTransferData");
+                    logger.Trace("Did not receive correct response from SendTransferData");
                 }
 
                 CastProgressWriteEvent(100);
             }
             else
             {
-                Console.WriteLine("requestDownload() failed");
+                logger.Trace("requestDownload() failed");
                 return false;
             }
             return true;
@@ -4087,7 +4087,7 @@ namespace TrionicCANLib.API
                 {
                     iFrameNumber = 0x21;
                     //10 F0 36 00 00 10 24 00
-                    //Console.WriteLine("Sending bootloader: " + startAddress.ToString("X8"));
+                    //logger.Trace("Sending bootloader: " + startAddress.ToString("X8"));
                     // cast event
                     int percentage = (int)(((float)i * 100) / 70F);
                     if (percentage > saved_progress)
@@ -4130,7 +4130,7 @@ namespace TrionicCANLib.API
                     }
                     else
                     {
-                        Console.WriteLine("Did not receive correct response from SendTransferData");
+                        logger.Trace("Did not receive correct response from SendTransferData");
                     }
                 }
 
@@ -4163,7 +4163,7 @@ namespace TrionicCANLib.API
                 }
                 else
                 {
-                    Console.WriteLine("Did not receive correct response from SendTransferData");
+                    logger.Trace("Did not receive correct response from SendTransferData");
                 }
 
                 CastProgressWriteEvent(100);
@@ -4176,7 +4176,7 @@ namespace TrionicCANLib.API
             BackgroundWorker bw = sender as BackgroundWorker;
             string filename = (string)workEvent.Argument;
             string diagDataID = GetDiagnosticDataIdentifier0101();
-            Console.WriteLine("DataID: " + diagDataID);
+            logger.Trace("DataID: " + diagDataID);
             if (diagDataID == string.Empty)
             {
                 canUsbDevice.SetupCANFilter("7E8", "000");
@@ -4847,7 +4847,7 @@ namespace TrionicCANLib.API
                 }
                 else
                 {
-                    Console.WriteLine("Rx: " + data.ToString("X16"));
+                    logger.Trace("Rx: " + data.ToString("X16"));
                     if (canUsbDevice is CANELM327Device)
                     {
                         if (recoveryMode) BroadcastKeepAlive();
@@ -4891,7 +4891,7 @@ namespace TrionicCANLib.API
             cmd |= (addressMiddle * 0x1000000000000);
             cmd |= (addressHigh * 0x10000000000);
             cmd |= (len * 0x100);
-            //Console.WriteLine("send: " + cmd.ToString("X16"));
+            //logger.Trace("send: " + cmd.ToString("X16"));
             msg.elmExpectedResponses = 1;
             msg.setData(cmd);
             m_canListener.setupWaitMessage(waitforResponseID);
@@ -4904,7 +4904,7 @@ namespace TrionicCANLib.API
             response = new CANMessage();
             response = m_canListener.waitMessage(1000);
             ulong data = response.getData();
-            //Console.WriteLine("Received in SendTransferData: " + data.ToString("X16"));
+            //logger.Trace("Received in SendTransferData: " + data.ToString("X16"));
             if (getCanData(data, 0) != 0x30 || getCanData(data, 1) != 0x00)
             {
                 return false;
@@ -4927,7 +4927,7 @@ namespace TrionicCANLib.API
             cmd |= (addressMiddle * 0x1000000000000);
             cmd |= (addressHigh * 0x10000000000);
             cmd |= (len * 0x100);
-            //Console.WriteLine("send: " + cmd.ToString("X16"));
+            //logger.Trace("send: " + cmd.ToString("X16"));
 
             msg.setData(cmd);
             msg.elmExpectedResponses = 1;
@@ -4941,7 +4941,7 @@ namespace TrionicCANLib.API
             response = new CANMessage();
             response = m_canListener.waitMessage(1000);
             ulong data = response.getData();
-            //Console.WriteLine("Received in SendTransferData: " + data.ToString("X16"));
+            //logger.Trace("Received in SendTransferData: " + data.ToString("X16"));
             if (getCanData(data, 0) != 0x30 || getCanData(data, 1) != 0x00)
             {
                 return false;
@@ -5077,7 +5077,7 @@ namespace TrionicCANLib.API
             //optimize reading speed for ELM
             if (length <= 3)
                 msg.elmExpectedResponses = 1;
-            //Console.WriteLine("Reading " + address.ToString("X8") + " len: " + length.ToString("X2"));
+            //logger.Trace("Reading " + address.ToString("X8") + " len: " + length.ToString("X2"));
             ulong cmd = 0x0000000000002307; // always 2 bytes
             ulong addressHigh = (uint)address & 0x0000000000FF0000;
             addressHigh /= 0x10000;
@@ -5091,7 +5091,7 @@ namespace TrionicCANLib.API
             cmd |= (addressMiddle * 0x100000000);
             cmd |= (addressHigh * 0x1000000);
             cmd |= (len * 0x100000000000000);
-            //Console.WriteLine("send: " + cmd.ToString("X16"));
+            //logger.Trace("send: " + cmd.ToString("X16"));
             /*cmd |= (ulong)(byte)(address & 0x000000FF) << 4 * 8;
             cmd |= (ulong)(byte)((address & 0x0000FF00) >> 8) << 3 * 8;
             cmd |= (ulong)(byte)((address & 0x00FF0000) >> 2 * 8) << 2 * 8;
@@ -5366,7 +5366,7 @@ namespace TrionicCANLib.API
                 }
                 else
                 {
-                    Console.WriteLine("Rx: " + data.ToString("X16"));
+                    logger.Trace("Rx: " + data.ToString("X16"));
                     if (canUsbDevice is CANELM327Device)
                     {
                         if (recoveryMode) BroadcastKeepAlive();
@@ -5490,7 +5490,7 @@ namespace TrionicCANLib.API
             cmd |= (addressMiddle * 0x1000000000000);
             cmd |= (addressHigh * 0x10000000000);
             cmd |= (len * 0x100);
-            Console.WriteLine("send: " + cmd.ToString("X16"));
+            logger.Trace("send: " + cmd.ToString("X16"));
 
             msg.setData(cmd);
             msg.elmExpectedResponses = 1;
@@ -5504,7 +5504,7 @@ namespace TrionicCANLib.API
             response = new CANMessage();
             response = m_canListener.waitMessage(1000);
             ulong data = response.getData();
-            Console.WriteLine("Received in SendTransferData: " + data.ToString("X16"));
+            logger.Trace("Received in SendTransferData: " + data.ToString("X16"));
             if (getCanData(data, 0) != 0x30 || getCanData(data, 1) != 0x00)
             {
                 return false;

--- a/TrionicCANLib/WMI/COMPortInfo.cs
+++ b/TrionicCANLib/WMI/COMPortInfo.cs
@@ -16,7 +16,7 @@ using System.Management;
 // Example of how to use:
 //  foreach (COMPortInfo comPort in COMPortInfo.GetCOMPortsInfo())
 //  {
-//      Console.WriteLine(string.Format("{0} – {1}", comPort.Name, comPort.Description));
+//      logger.Trace(string.Format("{0} – {1}", comPort.Name, comPort.Description));
 //  }
 
 namespace TrionicCANLib.WMI
@@ -25,6 +25,7 @@ namespace TrionicCANLib.WMI
     {
         public string Name { get; set; }
         public string Description { get; set; }
+        private static Logger logger = LogManager.GetCurrentClassLogger();
 
         public static List<COMPortInfo> GetCOMPortsInfo()
         {

--- a/TrionicCANLib/WMI/COMPortInfo.cs
+++ b/TrionicCANLib/WMI/COMPortInfo.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Management;
-using NLog;
 
 // A way of using WMI to find the right COM port number from its 'friendly name'
 //
@@ -17,7 +16,7 @@ using NLog;
 // Example of how to use:
 //  foreach (COMPortInfo comPort in COMPortInfo.GetCOMPortsInfo())
 //  {
-//      logger.Trace(string.Format("{0} – {1}", comPort.Name, comPort.Description));
+//      logger.Debug(string.Format("{0} – {1}", comPort.Name, comPort.Description));
 //  }
 
 namespace TrionicCANLib.WMI
@@ -26,7 +25,6 @@ namespace TrionicCANLib.WMI
     {
         public string Name { get; set; }
         public string Description { get; set; }
-        private static Logger logger = LogManager.GetCurrentClassLogger();
 
         public static List<COMPortInfo> GetCOMPortsInfo()
         {

--- a/TrionicCANLib/WMI/COMPortInfo.cs
+++ b/TrionicCANLib/WMI/COMPortInfo.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Management;
+using NLog;
 
 // A way of using WMI to find the right COM port number from its 'friendly name'
 //

--- a/TrionicCANLib/flasher/T7Flasher.cs
+++ b/TrionicCANLib/flasher/T7Flasher.cs
@@ -297,12 +297,12 @@ namespace TrionicCANLib.Flasher
                 {
                     m_nrOfRetries++;
                 }
-                logger.Trace("Writing data to file: " + m_length + " bytes");
+                logger.Debug("Writing data to file: " + m_length + " bytes");
                 fileStream.Write(data, 0, nrOfBytes);
                 m_nrOfBytesRead += nrOfBytes;
             }
             fileStream.Close();
-            logger.Trace("Done reading");
+            logger.Debug("Done reading");
             m_kwpHandler.sendDataTransferExitRequest();
         }
 

--- a/TrionicCANLib/flasher/T7Flasher.cs
+++ b/TrionicCANLib/flasher/T7Flasher.cs
@@ -19,7 +19,7 @@ namespace TrionicCANLib.Flasher
     {
         public override event IFlasher.StatusChanged onStatusChanged;
 
-        private Logger logger = LogManager.GetCurrentClassLogger();
+        private static Logger logger = LogManager.GetCurrentClassLogger();
 
         /// <summary>
         /// This method returns the number of bytes that has been read or written so far.
@@ -297,12 +297,12 @@ namespace TrionicCANLib.Flasher
                 {
                     m_nrOfRetries++;
                 }
-                Console.WriteLine("Writing data to file: " + m_length + " bytes");
+                logger.Trace("Writing data to file: " + m_length + " bytes");
                 fileStream.Write(data, 0, nrOfBytes);
                 m_nrOfBytesRead += nrOfBytes;
             }
             fileStream.Close();
-            Console.WriteLine("Done reading");
+            logger.Trace("Done reading");
             m_kwpHandler.sendDataTransferExitRequest();
         }
 


### PR DESCRIPTION
i've added a method "ReadValueFromSRAM" in Trionic7.cs and copied and overriden the method "SendReadRequest" in KWPHandler.cs, to request can messages in a faster way to get values by sramaddress, so responsetime is 2/3 to 1/2 time faster then current

i guess in the t8 suite it is also useable and has to bee implemented. but i have no t8 car so i won't do it cause i can not test on my own.

also i've changed every console.writeline in logger.trace and added NLog

regards